### PR TITLE
Add gazebo plugins to rosdep dependencies

### DIFF
--- a/rmf_gazebo_plugins/package.xml
+++ b/rmf_gazebo_plugins/package.xml
@@ -16,8 +16,6 @@
 
   <depend>rclcpp</depend>
   <depend>gazebo_ros_pkgs</depend>
-  <depend>gazebo_msgs</depend>
-  <depend>gazebo_dev</depend>
 
   <depend>std_msgs</depend>
   

--- a/rmf_gazebo_plugins/package.xml
+++ b/rmf_gazebo_plugins/package.xml
@@ -15,7 +15,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>gazebo_ros</depend>
+  <depend>gazebo_ros_pkgs</depend>
   <depend>gazebo_msgs</depend>
   <depend>gazebo_dev</depend>
 


### PR DESCRIPTION
Change from gazebo_ros to gazebo_ros_pkgs to include gazebo_plugins (such as skidsteer)