### PR TITLE
generalizing the level parameter in launch files

### DIFF
--- a/demos/launch/airport_terminal.launch.xml
+++ b/demos/launch/airport_terminal.launch.xml
@@ -7,6 +7,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/airport_terminal/airport_terminal.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/airport_terminal/airport_terminal.building.yaml"/>
+    <arg name="map_name" value="L1"/>
   </include>
 
   <group>

--- a/demos/launch/common.launch.xml
+++ b/demos/launch/common.launch.xml
@@ -5,6 +5,7 @@
   <arg name="use_sim_time" default="false" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="viz_config_file" default="$(find-pkg-share rmf_schedule_visualizer)/config/rmf.rviz"/>
   <arg name="config_file" description="Building description file required by building_map_tools"/>
+  <arg name="map_name" default="L1"/>
  
   <!-- Traffic Schedule  -->
   <node pkg="rmf_traffic_ros2" exec="rmf_traffic_schedule" output="both">
@@ -19,7 +20,7 @@
 
   <!-- Visualizer -->
   <include file="$(find-pkg-share visualizer)/visualizer.xml">
-    <arg name="map_name" value="L1"/>
+    <arg name="map_name" value="$(var map_name)"/>
     <arg name="viz_config_file" value ="$(var viz_config_file)"/>
   </include>
 

--- a/demos/launch/office.launch.xml
+++ b/demos/launch/office.launch.xml
@@ -7,6 +7,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/office/office.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/office/office.building.yaml"/>
+  <arg name="map_name" value="L1"/>
   </include>
 
   <group>


### PR DESCRIPTION
The level parameter is currently specified in the common.launch.xml file, without any exposure to the "super" launch file, for example office.launch.xml. As a result, to fix the level, i have to edit the common.launch.xml file directly.

This pull request proposes to move the parameter up one level, while at the same time specifying a default value of "L1".