### PR TITLE
reset payload pose to initial pose after 3.0s

### DIFF
--- a/rmf_gazebo_plugins/src/readonly.cpp
+++ b/rmf_gazebo_plugins/src/readonly.cpp
@@ -13,34 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
-#include <gazebo/physics/World.hh>
-#include <gazebo/physics/Model.hh>
 #include <gazebo/physics/Joint.hh>
 #include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
 #include <gazebo_ros/node.hpp>
 
-#include <rclcpp/rclcpp.hpp>
 #include <rclcpp/logger.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <memory>
-#include <unordered_map>
 #include <mutex>
+#include <unordered_map>
 
 #include <gazebo/common/Plugin.hh>
 
-#include <rmf_fleet_msgs/msg/robot_state.hpp>
 #include <building_map_msgs/msg/building_map.hpp>
-#include <building_map_msgs/msg/level.hpp>
 #include <building_map_msgs/msg/graph.hpp>
+#include <building_map_msgs/msg/level.hpp>
+#include <rmf_fleet_msgs/msg/robot_state.hpp>
 
 #include "utils.hpp"
 
 using namespace rmf_gazebo_plugins;
 
-class ReadonlyPlugin : public gazebo::ModelPlugin
-{
+class ReadonlyPlugin : public gazebo::ModelPlugin {
 public:
   using BuildingMap = building_map_msgs::msg::BuildingMap;
   using Level = building_map_msgs::msg::Level;
@@ -56,22 +55,22 @@ public:
   void OnUpdate();
 
 private:
-
   rclcpp::Logger logger();
 
   void set_traits();
   void initialize_graph();
-  void initialize_start(const ignition::math::Pose3d& pose);
-  double compute_ds(const ignition::math::Pose3d& pose, const std::size_t& wp);
+  void initialize_start(const ignition::math::Pose3d &pose);
+  double compute_ds(const ignition::math::Pose3d &pose, const std::size_t &wp);
   std::size_t get_next_waypoint(const std::size_t start_wp,
-      const ignition::math::Vector3d& heading);
-  Path compute_path(const ignition::math::Pose3d& pose);
+                                const ignition::math::Vector3d &heading);
+  Path compute_path(const ignition::math::Pose3d &pose);
 
   gazebo::event::ConnectionPtr _update_connection;
   gazebo_ros::Node::SharedPtr _ros_node;
   gazebo::physics::ModelPtr _model;
 
-  rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr _robot_state_pub;
+  rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr
+      _robot_state_pub;
   rclcpp::Subscription<BuildingMap>::SharedPtr _building_map_sub;
 
   rmf_fleet_msgs::msg::RobotState _robot_state_msg;
@@ -102,7 +101,8 @@ private:
   std::size_t _start_wp;
   std::vector<std::size_t> _next_wp;
 
-  std::unordered_map<std::size_t, std::unordered_set<std::size_t>> _neighbor_map;
+  std::unordered_map<std::size_t, std::unordered_set<std::size_t>>
+      _neighbor_map;
 
   double _last_update_time = 0.0;
   int _update_count = 0;
@@ -117,9 +117,7 @@ ReadonlyPlugin::ReadonlyPlugin()
   // We do initialization only during ::Load
 }
 
-ReadonlyPlugin::~ReadonlyPlugin()
-{
-}
+ReadonlyPlugin::~ReadonlyPlugin() {}
 
 rclcpp::Logger ReadonlyPlugin::logger()
 {
@@ -154,75 +152,75 @@ void ReadonlyPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
 
   if (sdf->HasElement("nominal_drive_speed"))
     _v_n = sdf->Get<double>("nominal_drive_speed");
-  RCLCPP_INFO(logger(), "Setting nominal drive speed to: " + std::to_string(_v_n));
+  RCLCPP_INFO(logger(),
+              "Setting nominal drive speed to: " + std::to_string(_v_n));
 
   if (sdf->HasElement("nominal_drive_acceleration"))
     _a_n = sdf->Get<double>("nominal_drive_acceleration");
-  RCLCPP_INFO(logger(), "Setting nominal drive acceleration to: " + std::to_string(_a_n));
+  RCLCPP_INFO(logger(),
+              "Setting nominal drive acceleration to: " + std::to_string(_a_n));
 
   if (sdf->HasElement("nominal_turn_speed"))
     _w_n = sdf->Get<double>("nominal_turn_speed");
-  RCLCPP_INFO(logger(), "Setting nominal turn speed to:" + std::to_string(_w_n));
+  RCLCPP_INFO(logger(),
+              "Setting nominal turn speed to:" + std::to_string(_w_n));
 
   if (sdf->HasElement("nominal_turn_acceleration"))
     _alpha_n = sdf->Get<double>("nominal_turn_acceleration");
-  RCLCPP_INFO(logger(), "Setting nominal turn acceleration to:" + std::to_string(_alpha_n));
+  RCLCPP_INFO(logger(), "Setting nominal turn acceleration to:" +
+                            std::to_string(_alpha_n));
 
   RCLCPP_INFO(logger(), "hello i am " + model->GetName());
 
   _update_connection = gazebo::event::Events::ConnectWorldUpdateBegin(
       std::bind(&ReadonlyPlugin::OnUpdate, this));
 
-  _robot_state_pub = _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>(
-      "/robot_state", 10);
+  _robot_state_pub =
+      _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>(
+          "/robot_state", 10);
 
   // Subscription to /map
   auto qos_profile = rclcpp::QoS(10);
   qos_profile.transient_local();
   _building_map_sub = _ros_node->create_subscription<BuildingMap>(
-        "/map",
-        qos_profile,
-        std::bind(&ReadonlyPlugin::map_cb, this, std::placeholders::_1));
+      "/map", qos_profile,
+      std::bind(&ReadonlyPlugin::map_cb, this, std::placeholders::_1));
 
   _current_task_id = "demo";
   if (model->GetName().c_str())
-  _name = _model->GetName().c_str();
+    _name = _model->GetName().c_str();
   RCLCPP_INFO(logger(), "Setting name to: " + _name);
-
 }
 
 void ReadonlyPlugin::map_cb(const BuildingMap::SharedPtr msg)
 {
-  if (msg->levels.empty())
-  {
+  if (msg->levels.empty()) {
     RCLCPP_ERROR(logger(), "Received empty building map");
     return;
   }
 
-  RCLCPP_INFO(logger(), "Received building map with %d levels", msg->levels.size());
+  RCLCPP_INFO(logger(), "Received building map with %d levels",
+              msg->levels.size());
   _found_level = false;
   _found_graph = false;
-  for (const auto& level: msg->levels)
-  {
+  for (const auto &level : msg->levels) {
     RCLCPP_INFO(logger(), "Level name: [%s]", level.name.c_str());
-    if (level.name.c_str() == _level_name)
-    {
+    if (level.name.c_str() == _level_name) {
       _level = level;
       _found_level = true;
       RCLCPP_INFO(logger(), "Found level [%s] with %d nav_graphs",
-          level.name.c_str(), level.nav_graphs.size());
+                  level.name.c_str(), level.nav_graphs.size());
 
-      if (_nav_graph_index < level.nav_graphs.size())
-      {
+      if (_nav_graph_index < level.nav_graphs.size()) {
         _found_graph = true;
         RCLCPP_INFO(logger(), "Graph index [%d] containts [%d] waypoints",
-            _nav_graph_index,
-            level.nav_graphs[_nav_graph_index].vertices.size());
+                    _nav_graph_index,
+                    level.nav_graphs[_nav_graph_index].vertices.size());
         initialize_graph();
       }
-      else
-      {
-        RCLCPP_ERROR(logger(),
+      else {
+        RCLCPP_ERROR(
+            logger(),
             "Specified nav_graph index [%d] does not exist in level [%s]",
             _nav_graph_index, _level_name.c_str());
       }
@@ -231,7 +229,8 @@ void ReadonlyPlugin::map_cb(const BuildingMap::SharedPtr msg)
   }
 
   if (!_found_level)
-    RCLCPP_ERROR(logger(),
+    RCLCPP_ERROR(
+        logger(),
         "Did not find level [%s] in building map. Path will not be published.",
         _level_name.c_str());
 }
@@ -240,70 +239,59 @@ void ReadonlyPlugin::initialize_graph()
 {
   if (!_found_graph)
     return;
-  
+
   std::lock_guard<std::mutex> lock(_mutex);
 
   _initialized_graph = false;
 
   _graph = _level.nav_graphs[_nav_graph_index];
-  RCLCPP_INFO(logger(), "Nav graph contains [%d] lanes" , _graph.edges.size());
-  for (const auto& edge : _graph.edges)
-  {
+  RCLCPP_INFO(logger(), "Nav graph contains [%d] lanes", _graph.edges.size());
+  for (const auto &edge : _graph.edges) {
     // Inserting entry for v1_idx
     auto entry = _neighbor_map.find(edge.v1_idx);
-    if (entry == _neighbor_map.end())
-    {
+    if (entry == _neighbor_map.end()) {
       // We assume the vertex is a neighbor of itself to account for when the
       // robot turns around and heads back to the start index
       std::unordered_set<std::size_t> neighbors({edge.v1_idx, edge.v2_idx});
       _neighbor_map.insert(std::make_pair(edge.v1_idx, neighbors));
     }
     // Updating existing entry
-    else
-    {
+    else {
       entry->second.insert(edge.v2_idx);
     }
 
     // If bidrectional, add entry for v2_idx
-    if (edge.edge_type == edge.EDGE_TYPE_BIDIRECTIONAL)
-    {
+    if (edge.edge_type == edge.EDGE_TYPE_BIDIRECTIONAL) {
       entry = _neighbor_map.find(edge.v2_idx);
-      if (entry == _neighbor_map.end())
-      {
+      if (entry == _neighbor_map.end()) {
         std::unordered_set<std::size_t> neighbors({edge.v1_idx, edge.v2_idx});
         _neighbor_map.insert(std::make_pair(edge.v2_idx, neighbors));
       }
       // Updating existing entry
-      else
-      {
+      else {
         entry->second.insert(edge.v1_idx);
       }
     }
-
   }
 
   _initialized_graph = true;
-
 }
 
-double ReadonlyPlugin::compute_ds(
-    const ignition::math::Pose3d& pose,
-    const std::size_t& wp)
+double ReadonlyPlugin::compute_ds(const ignition::math::Pose3d &pose,
+                                  const std::size_t &wp)
 {
   // TODO consider returning a nullptr instead
   assert(_found_graph);
   assert(wp < _graph.vertices.size());
-  
+
   ignition::math::Vector3d world_position{pose.Pos().X(), pose.Pos().Y(), 0};
-  ignition::math::Vector3d graph_position{
-    _graph.vertices[wp].x,
-    _graph.vertices[wp].y,
-    0};
+  ignition::math::Vector3d graph_position{_graph.vertices[wp].x,
+                                          _graph.vertices[wp].y, 0};
 
   return std::abs((world_position - graph_position).Length());
 }
 
-void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d& pose)
+void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d &pose)
 {
   if (_initialized_start)
     return;
@@ -312,10 +300,8 @@ void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d& pose)
     return;
 
   bool found = false;
-  for (std::size_t i = 0; i < _graph.vertices.size(); i++)
-  {
-    if (_graph.vertices[i].name.c_str() == _start_wp_name)
-    {
+  for (std::size_t i = 0; i < _graph.vertices.size(); i++) {
+    if (_graph.vertices[i].name.c_str() == _start_wp_name) {
       found = true;
       _start_wp = i;
       RCLCPP_INFO(logger(), "Start waypoint found in nav graph");
@@ -323,51 +309,44 @@ void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d& pose)
   }
 
   // TODO find the closest wp if the coordiantes do not match
-  if (found && compute_ds(pose, _start_wp) < 1e-1)
-  {
+  if (found && compute_ds(pose, _start_wp) < 1e-1) {
     _initialized_start = true;
     // Here we initialzie the next waypoint
     compute_path(pose);
     RCLCPP_INFO(logger(), "Start waypoint successfully initialized");
   }
 
-  else if (found)
-  {
-    RCLCPP_ERROR(
-      logger(),
-      "Spawn coordinates [%f,%f,%f] differs from that of waypoint [%s] in nav_graph [%f, %f, %f]",
-       pose.Pos().X(), pose.Pos().Y(),0,
-      _start_wp_name.c_str(),
-      _graph.vertices[_start_wp].x, _graph.vertices[_start_wp].y, 0);
+  else if (found) {
+    RCLCPP_ERROR(logger(),
+                 "Spawn coordinates [%f,%f,%f] differs from that of waypoint "
+                 "[%s] in nav_graph [%f, %f, %f]",
+                 pose.Pos().X(), pose.Pos().Y(), 0, _start_wp_name.c_str(),
+                 _graph.vertices[_start_wp].x, _graph.vertices[_start_wp].y, 0);
   }
 
-  else
-  {
-    RCLCPP_ERROR(
-      logger(),
-      "Start waypoint [%s] not found in nav graph", _start_wp_name.c_str());
+  else {
+    RCLCPP_ERROR(logger(), "Start waypoint [%s] not found in nav graph",
+                 _start_wp_name.c_str());
   }
 }
-std::size_t ReadonlyPlugin::get_next_waypoint(const std::size_t start_wp,
-    const ignition::math::Vector3d& heading)
+std::size_t
+ReadonlyPlugin::get_next_waypoint(const std::size_t start_wp,
+                                  const ignition::math::Vector3d &heading)
 {
   // Return the waypoint closest to the robot in the direction of its heading
-  const auto& neighbors = _neighbor_map.find(start_wp)->second;
+  const auto &neighbors = _neighbor_map.find(start_wp)->second;
 
   auto wp_it = neighbors.begin();
   double max_dist = std::numeric_limits<double>::min();
 
-  for (auto it = neighbors.begin(); it != neighbors.end(); it++)
-  {
-    const auto& waypoint = _graph.vertices[*it];
+  for (auto it = neighbors.begin(); it != neighbors.end(); it++) {
+    const auto &waypoint = _graph.vertices[*it];
     ignition::math::Vector3d disp_vector{
         waypoint.x - _graph.vertices[start_wp].x,
-        waypoint.y - _graph.vertices[start_wp].y,
-        0};
+        waypoint.y - _graph.vertices[start_wp].y, 0};
     const double dist = heading.Dot(disp_vector.Normalize());
     // Consider the waypoints with largest projected distance
-    if (dist > max_dist)
-    {
+    if (dist > max_dist) {
       max_dist = dist;
       wp_it = it;
     }
@@ -376,18 +355,18 @@ std::size_t ReadonlyPlugin::get_next_waypoint(const std::size_t start_wp,
   return *wp_it;
 }
 
-ReadonlyPlugin::Path ReadonlyPlugin::compute_path(const ignition::math::Pose3d& pose)
+ReadonlyPlugin::Path
+ReadonlyPlugin::compute_path(const ignition::math::Pose3d &pose)
 {
   Path path;
   path.resize(_lookahead);
-  
+
   auto start_wp = _start_wp;
   const double current_yaw = pose.Rot().Euler().Z();
-  ignition::math::Vector3d heading{
-      std::cos(current_yaw), std::sin(current_yaw), 0.0};
-  
-  for (std::size_t i = 0; i < _lookahead; i++)
-  {
+  ignition::math::Vector3d heading{std::cos(current_yaw), std::sin(current_yaw),
+                                   0.0};
+
+  for (std::size_t i = 0; i < _lookahead; i++) {
     std::lock_guard<std::mutex> lock(_mutex);
     auto wp = get_next_waypoint(start_wp, heading);
     _next_wp[i] = wp;
@@ -399,21 +378,19 @@ ReadonlyPlugin::Path ReadonlyPlugin::compute_path(const ignition::math::Pose3d& 
     path[i] = location;
     // Update heading for next iteration
     auto next_heading = ignition::math::Vector3d{
-      _graph.vertices[wp].x - _graph.vertices[start_wp].x,
-      _graph.vertices[wp].y - _graph.vertices[start_wp].y,
-      0};
+        _graph.vertices[wp].x - _graph.vertices[start_wp].x,
+        _graph.vertices[wp].y - _graph.vertices[start_wp].y, 0};
     heading = next_heading.Normalize();
     start_wp = wp;
   }
 
   return path;
-
 }
 
 void ReadonlyPlugin::OnUpdate()
 {
   _update_count++;
-  const auto& world = _model->GetWorld();
+  const auto &world = _model->GetWorld();
   auto pose = _model->WorldPose();
 
   if (_update_count % 100 == 0) // todo: be smarter, use elapsed sim time
@@ -424,7 +401,7 @@ void ReadonlyPlugin::OnUpdate()
     _last_update_time = time;
     const int32_t t_sec = static_cast<int32_t>(time);
     const uint32_t t_nsec =
-        static_cast<uint32_t>((time-static_cast<double>(t_sec)) *1e9);
+        static_cast<uint32_t>((time - static_cast<double>(t_sec)) * 1e9);
     const rclcpp::Time now{t_sec, t_nsec, RCL_ROS_TIME};
 
     _robot_state_msg.name = _model->GetName();
@@ -438,21 +415,18 @@ void ReadonlyPlugin::OnUpdate()
     _robot_state_msg.location.yaw = pose.Rot().Yaw();
     _robot_state_msg.location.t = now;
     _robot_state_msg.location.level_name = _level_name;
-    
-    if (_initialized_start)
-    {
-      if (compute_ds(pose, _next_wp[0]) <= 2.0)
-      {
+
+    if (_initialized_start) {
+      if (compute_ds(pose, _next_wp[0]) <= 2.0) {
         _start_wp = _next_wp[0];
-        RCLCPP_INFO(logger(), "Reached waypoint [%d,%s]",
-            _next_wp[0], _graph.vertices[_next_wp[0]].name.c_str());
+        RCLCPP_INFO(logger(), "Reached waypoint [%d,%s]", _next_wp[0],
+                    _graph.vertices[_next_wp[0]].name.c_str());
       }
       _robot_state_msg.path = compute_path(pose);
     }
 
     _robot_state_pub->publish(_robot_state_msg);
   }
-
 }
 
 GZ_REGISTER_MODEL_PLUGIN(ReadonlyPlugin)

--- a/rmf_gazebo_plugins/src/readonly.cpp
+++ b/rmf_gazebo_plugins/src/readonly.cpp
@@ -43,10 +43,10 @@ class ReadonlyPlugin : public gazebo::ModelPlugin
 {
 public:
   using BuildingMap = building_map_msgs::msg::BuildingMap;
-  using Level = building_map_msgs::msg::Level;
-  using Graph = building_map_msgs::msg::Graph;
-  using Location = rmf_fleet_msgs::msg::Location;
-  using Path = std::vector<Location>;
+  using Level       = building_map_msgs::msg::Level;
+  using Graph       = building_map_msgs::msg::Graph;
+  using Location    = rmf_fleet_msgs::msg::Location;
+  using Path        = std::vector<Location>;
 
   ReadonlyPlugin();
   ~ReadonlyPlugin();
@@ -62,16 +62,14 @@ private:
   void initialize_graph();
   void initialize_start(const ignition::math::Pose3d &pose);
   double compute_ds(const ignition::math::Pose3d &pose, const std::size_t &wp);
-  std::size_t get_next_waypoint(const std::size_t start_wp,
-                                const ignition::math::Vector3d &heading);
+  std::size_t get_next_waypoint(const std::size_t start_wp, const ignition::math::Vector3d &heading);
   Path compute_path(const ignition::math::Pose3d &pose);
 
   gazebo::event::ConnectionPtr _update_connection;
   gazebo_ros::Node::SharedPtr _ros_node;
   gazebo::physics::ModelPtr _model;
 
-  rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr
-      _robot_state_pub;
+  rclcpp::Publisher<rmf_fleet_msgs::msg::RobotState>::SharedPtr _robot_state_pub;
   rclcpp::Subscription<BuildingMap>::SharedPtr _building_map_sub;
 
   rmf_fleet_msgs::msg::RobotState _robot_state_msg;
@@ -79,13 +77,13 @@ private:
 
   Path _path;
   // These are currently unused but may be needed if the Planner api is used
-  double _v_n = 0.7;
-  double _a_n = 0.5;
-  double _w_n = 0.6;
+  double _v_n     = 0.7;
+  double _a_n     = 0.5;
+  double _w_n     = 0.6;
   double _alpha_n = 1.5;
 
-  bool _found_level = false;
-  bool _found_graph = false;
+  bool _found_level       = false;
+  bool _found_graph       = false;
   bool _initialized_graph = false;
   bool _initialized_start = false;
 
@@ -94,19 +92,18 @@ private:
   Level _level;
   Graph _graph;
 
-  std::string _level_name = "L1";
+  std::string _level_name      = "L1";
   std::size_t _nav_graph_index = 1;
-  std::string _start_wp_name = "caddy";
+  std::string _start_wp_name   = "caddy";
   // The number of waypoints to add to the predicted path. Minimum is 1.
   std::size_t _lookahead = 1;
   std::size_t _start_wp;
   std::vector<std::size_t> _next_wp;
 
-  std::unordered_map<std::size_t, std::unordered_set<std::size_t>>
-      _neighbor_map;
+  std::unordered_map<std::size_t, std::unordered_set<std::size_t>> _neighbor_map;
 
   double _last_update_time = 0.0;
-  int _update_count = 0;
+  int _update_count        = 0;
   std::string _name;
   std::string _current_task_id;
 
@@ -120,16 +117,13 @@ ReadonlyPlugin::ReadonlyPlugin()
 
 ReadonlyPlugin::~ReadonlyPlugin() {}
 
-rclcpp::Logger ReadonlyPlugin::logger()
-{
-  return rclcpp::get_logger("read_only_" + _model->GetName());
-}
+rclcpp::Logger ReadonlyPlugin::logger() { return rclcpp::get_logger("read_only_" + _model->GetName()); }
 
 void ReadonlyPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
 {
   _current_mode.mode = rmf_fleet_msgs::msg::RobotMode::MODE_MOVING;
-  _model = model;
-  _ros_node = gazebo_ros::Node::Get(sdf);
+  _model             = model;
+  _ros_node          = gazebo_ros::Node::Get(sdf);
 
   // Getting sdf elements
   if (sdf->HasElement("level_name"))
@@ -153,39 +147,31 @@ void ReadonlyPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
 
   if (sdf->HasElement("nominal_drive_speed"))
     _v_n = sdf->Get<double>("nominal_drive_speed");
-  RCLCPP_INFO(logger(),
-              "Setting nominal drive speed to: " + std::to_string(_v_n));
+  RCLCPP_INFO(logger(), "Setting nominal drive speed to: " + std::to_string(_v_n));
 
   if (sdf->HasElement("nominal_drive_acceleration"))
     _a_n = sdf->Get<double>("nominal_drive_acceleration");
-  RCLCPP_INFO(logger(),
-              "Setting nominal drive acceleration to: " + std::to_string(_a_n));
+  RCLCPP_INFO(logger(), "Setting nominal drive acceleration to: " + std::to_string(_a_n));
 
   if (sdf->HasElement("nominal_turn_speed"))
     _w_n = sdf->Get<double>("nominal_turn_speed");
-  RCLCPP_INFO(logger(),
-              "Setting nominal turn speed to:" + std::to_string(_w_n));
+  RCLCPP_INFO(logger(), "Setting nominal turn speed to:" + std::to_string(_w_n));
 
   if (sdf->HasElement("nominal_turn_acceleration"))
     _alpha_n = sdf->Get<double>("nominal_turn_acceleration");
-  RCLCPP_INFO(logger(), "Setting nominal turn acceleration to:" +
-                            std::to_string(_alpha_n));
+  RCLCPP_INFO(logger(), "Setting nominal turn acceleration to:" + std::to_string(_alpha_n));
 
   RCLCPP_INFO(logger(), "hello i am " + model->GetName());
 
-  _update_connection = gazebo::event::Events::ConnectWorldUpdateBegin(
-      std::bind(&ReadonlyPlugin::OnUpdate, this));
+  _update_connection = gazebo::event::Events::ConnectWorldUpdateBegin(std::bind(&ReadonlyPlugin::OnUpdate, this));
 
-  _robot_state_pub =
-      _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>(
-          "/robot_state", 10);
+  _robot_state_pub = _ros_node->create_publisher<rmf_fleet_msgs::msg::RobotState>("/robot_state", 10);
 
   // Subscription to /map
   auto qos_profile = rclcpp::QoS(10);
   qos_profile.transient_local();
   _building_map_sub = _ros_node->create_subscription<BuildingMap>(
-      "/map", qos_profile,
-      std::bind(&ReadonlyPlugin::map_cb, this, std::placeholders::_1));
+      "/map", qos_profile, std::bind(&ReadonlyPlugin::map_cb, this, std::placeholders::_1));
 
   _current_task_id = "demo";
   if (model->GetName().c_str())
@@ -201,8 +187,7 @@ void ReadonlyPlugin::map_cb(const BuildingMap::SharedPtr msg)
     return;
   }
 
-  RCLCPP_INFO(logger(), "Received building map with %d levels",
-              msg->levels.size());
+  RCLCPP_INFO(logger(), "Received building map with %d levels", msg->levels.size());
   _found_level = false;
   _found_graph = false;
   for (const auto &level : msg->levels)
@@ -210,35 +195,28 @@ void ReadonlyPlugin::map_cb(const BuildingMap::SharedPtr msg)
     RCLCPP_INFO(logger(), "Level name: [%s]", level.name.c_str());
     if (level.name.c_str() == _level_name)
     {
-      _level = level;
+      _level       = level;
       _found_level = true;
-      RCLCPP_INFO(logger(), "Found level [%s] with %d nav_graphs",
-                  level.name.c_str(), level.nav_graphs.size());
+      RCLCPP_INFO(logger(), "Found level [%s] with %d nav_graphs", level.name.c_str(), level.nav_graphs.size());
 
       if (_nav_graph_index < level.nav_graphs.size())
       {
         _found_graph = true;
-        RCLCPP_INFO(logger(), "Graph index [%d] containts [%d] waypoints",
-                    _nav_graph_index,
+        RCLCPP_INFO(logger(), "Graph index [%d] containts [%d] waypoints", _nav_graph_index,
                     level.nav_graphs[_nav_graph_index].vertices.size());
         initialize_graph();
       }
       else
       {
-        RCLCPP_ERROR(
-            logger(),
-            "Specified nav_graph index [%d] does not exist in level [%s]",
-            _nav_graph_index, _level_name.c_str());
+        RCLCPP_ERROR(logger(), "Specified nav_graph index [%d] does not exist in level [%s]", _nav_graph_index,
+                     _level_name.c_str());
       }
       break;
     }
   }
 
   if (!_found_level)
-    RCLCPP_ERROR(
-        logger(),
-        "Did not find level [%s] in building map. Path will not be published.",
-        _level_name.c_str());
+    RCLCPP_ERROR(logger(), "Did not find level [%s] in building map. Path will not be published.", _level_name.c_str());
 }
 
 void ReadonlyPlugin::initialize_graph()
@@ -289,16 +267,14 @@ void ReadonlyPlugin::initialize_graph()
   _initialized_graph = true;
 }
 
-double ReadonlyPlugin::compute_ds(const ignition::math::Pose3d &pose,
-                                  const std::size_t &wp)
+double ReadonlyPlugin::compute_ds(const ignition::math::Pose3d &pose, const std::size_t &wp)
 {
   // TODO consider returning a nullptr instead
   assert(_found_graph);
   assert(wp < _graph.vertices.size());
 
   ignition::math::Vector3d world_position{pose.Pos().X(), pose.Pos().Y(), 0};
-  ignition::math::Vector3d graph_position{_graph.vertices[wp].x,
-                                          _graph.vertices[wp].y, 0};
+  ignition::math::Vector3d graph_position{_graph.vertices[wp].x, _graph.vertices[wp].y, 0};
 
   return std::abs((world_position - graph_position).Length());
 }
@@ -316,7 +292,7 @@ void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d &pose)
   {
     if (_graph.vertices[i].name.c_str() == _start_wp_name)
     {
-      found = true;
+      found     = true;
       _start_wp = i;
       RCLCPP_INFO(logger(), "Start waypoint found in nav graph");
     }
@@ -336,72 +312,65 @@ void ReadonlyPlugin::initialize_start(const ignition::math::Pose3d &pose)
     RCLCPP_ERROR(logger(),
                  "Spawn coordinates [%f,%f,%f] differs from that of waypoint "
                  "[%s] in nav_graph [%f, %f, %f]",
-                 pose.Pos().X(), pose.Pos().Y(), 0, _start_wp_name.c_str(),
-                 _graph.vertices[_start_wp].x, _graph.vertices[_start_wp].y, 0);
+                 pose.Pos().X(), pose.Pos().Y(), 0, _start_wp_name.c_str(), _graph.vertices[_start_wp].x,
+                 _graph.vertices[_start_wp].y, 0);
   }
 
   else
   {
-    RCLCPP_ERROR(logger(), "Start waypoint [%s] not found in nav graph",
-                 _start_wp_name.c_str());
+    RCLCPP_ERROR(logger(), "Start waypoint [%s] not found in nav graph", _start_wp_name.c_str());
   }
 }
-std::size_t
-ReadonlyPlugin::get_next_waypoint(const std::size_t start_wp,
-                                  const ignition::math::Vector3d &heading)
+std::size_t ReadonlyPlugin::get_next_waypoint(const std::size_t start_wp, const ignition::math::Vector3d &heading)
 {
   // Return the waypoint closest to the robot in the direction of its heading
   const auto &neighbors = _neighbor_map.find(start_wp)->second;
 
-  auto wp_it = neighbors.begin();
+  auto wp_it      = neighbors.begin();
   double max_dist = std::numeric_limits<double>::min();
 
   for (auto it = neighbors.begin(); it != neighbors.end(); it++)
   {
     const auto &waypoint = _graph.vertices[*it];
-    ignition::math::Vector3d disp_vector{
-        waypoint.x - _graph.vertices[start_wp].x,
-        waypoint.y - _graph.vertices[start_wp].y, 0};
+    ignition::math::Vector3d disp_vector{waypoint.x - _graph.vertices[start_wp].x,
+                                         waypoint.y - _graph.vertices[start_wp].y, 0};
     const double dist = heading.Dot(disp_vector.Normalize());
     // Consider the waypoints with largest projected distance
     if (dist > max_dist)
     {
       max_dist = dist;
-      wp_it = it;
+      wp_it    = it;
     }
   }
 
   return *wp_it;
 }
 
-ReadonlyPlugin::Path
-ReadonlyPlugin::compute_path(const ignition::math::Pose3d &pose)
+ReadonlyPlugin::Path ReadonlyPlugin::compute_path(const ignition::math::Pose3d &pose)
 {
   Path path;
   path.resize(_lookahead);
 
-  auto start_wp = _start_wp;
+  auto start_wp            = _start_wp;
   const double current_yaw = pose.Rot().Euler().Z();
-  ignition::math::Vector3d heading{std::cos(current_yaw), std::sin(current_yaw),
-                                   0.0};
+  ignition::math::Vector3d heading{std::cos(current_yaw), std::sin(current_yaw), 0.0};
 
   for (std::size_t i = 0; i < _lookahead; i++)
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    auto wp = get_next_waypoint(start_wp, heading);
+    auto wp     = get_next_waypoint(start_wp, heading);
     _next_wp[i] = wp;
     // Add to path here
     Location location;
-    location.x = _graph.vertices[wp].x;
-    location.y = _graph.vertices[wp].y;
+    location.x          = _graph.vertices[wp].x;
+    location.y          = _graph.vertices[wp].y;
     location.level_name = _level_name;
-    path[i] = location;
+    path[i]             = location;
     // Update heading for next iteration
-    auto next_heading = ignition::math::Vector3d{
-        _graph.vertices[wp].x - _graph.vertices[start_wp].x,
-        _graph.vertices[wp].y - _graph.vertices[start_wp].y, 0};
-    heading = next_heading.Normalize();
-    start_wp = wp;
+    auto next_heading = ignition::math::Vector3d{_graph.vertices[wp].x - _graph.vertices[start_wp].x,
+                                                 _graph.vertices[wp].y - _graph.vertices[start_wp].y, 0};
+    heading           = next_heading.Normalize();
+    start_wp          = wp;
   }
 
   return path;
@@ -411,29 +380,28 @@ void ReadonlyPlugin::OnUpdate()
 {
   _update_count++;
   const auto &world = _model->GetWorld();
-  auto pose = _model->WorldPose();
+  auto pose         = _model->WorldPose();
 
   if (_update_count % 100 == 0) // todo: be smarter, use elapsed sim time
   {
     initialize_start(pose);
 
-    const double time = world->SimTime().Double();
-    _last_update_time = time;
-    const int32_t t_sec = static_cast<int32_t>(time);
-    const uint32_t t_nsec =
-        static_cast<uint32_t>((time - static_cast<double>(t_sec)) * 1e9);
+    const double time     = world->SimTime().Double();
+    _last_update_time     = time;
+    const int32_t t_sec   = static_cast<int32_t>(time);
+    const uint32_t t_nsec = static_cast<uint32_t>((time - static_cast<double>(t_sec)) * 1e9);
     const rclcpp::Time now{t_sec, t_nsec, RCL_ROS_TIME};
 
-    _robot_state_msg.name = _model->GetName();
-    _robot_state_msg.model = "";
-    _robot_state_msg.task_id = _current_task_id;
-    _robot_state_msg.mode = _current_mode;
+    _robot_state_msg.name            = _model->GetName();
+    _robot_state_msg.model           = "";
+    _robot_state_msg.task_id         = _current_task_id;
+    _robot_state_msg.mode            = _current_mode;
     _robot_state_msg.battery_percent = 98.0;
 
-    _robot_state_msg.location.x = pose.Pos().X();
-    _robot_state_msg.location.y = pose.Pos().Y();
-    _robot_state_msg.location.yaw = pose.Rot().Yaw();
-    _robot_state_msg.location.t = now;
+    _robot_state_msg.location.x          = pose.Pos().X();
+    _robot_state_msg.location.y          = pose.Pos().Y();
+    _robot_state_msg.location.yaw        = pose.Rot().Yaw();
+    _robot_state_msg.location.t          = now;
     _robot_state_msg.location.level_name = _level_name;
 
     if (_initialized_start)
@@ -441,8 +409,7 @@ void ReadonlyPlugin::OnUpdate()
       if (compute_ds(pose, _next_wp[0]) <= 2.0)
       {
         _start_wp = _next_wp[0];
-        RCLCPP_INFO(logger(), "Reached waypoint [%d,%s]", _next_wp[0],
-                    _graph.vertices[_next_wp[0]].name.c_str());
+        RCLCPP_INFO(logger(), "Reached waypoint [%d,%s]", _next_wp[0], _graph.vertices[_next_wp[0]].name.c_str());
       }
       _robot_state_msg.path = compute_path(pose);
     }

--- a/rmf_gazebo_plugins/src/teleport.cpp
+++ b/rmf_gazebo_plugins/src/teleport.cpp
@@ -34,7 +34,7 @@ class TeleportPlugin : public gazebo::ModelPlugin
 {
 public:
   using DispenserResult = rmf_dispenser_msgs::msg::DispenserResult;
-  using Pose3d = ignition::math::Pose3d;
+  using Pose3d          = ignition::math::Pose3d;
 
   // Pointer to the model
   gazebo::physics::ModelPtr _model;
@@ -68,9 +68,7 @@ public:
 
     _result_sub = _node->create_subscription<DispenserResult>(
         "/dispenser_results", rclcpp::SystemDefaultsQoS(),
-        [&](DispenserResult::UniquePtr msg) {
-          dispenser_result_cb(std::move(msg));
-        });
+        [&](DispenserResult::UniquePtr msg) { dispenser_result_cb(std::move(msg)); });
 
     _initial_pose = _model->WorldPose();
 
@@ -80,7 +78,7 @@ public:
   // Called by the world update start event
   void dispenser_result_cb(DispenserResult::UniquePtr msg)
   {
-    auto status = msg->status;
+    auto status             = msg->status;
     std::string source_guid = msg->source_guid.c_str();
 
     if (source_guid == _load_guid && !_object_loaded)

--- a/rmf_gazebo_plugins/src/teleport.cpp
+++ b/rmf_gazebo_plugins/src/teleport.cpp
@@ -27,9 +27,11 @@
 
 #include <rmf_dispenser_msgs/msg/dispenser_result.hpp>
 
-namespace rmf_gazebo_plugins {
+namespace rmf_gazebo_plugins
+{
 
-class TeleportPlugin : public gazebo::ModelPlugin {
+class TeleportPlugin : public gazebo::ModelPlugin
+{
 public:
   using DispenserResult = rmf_dispenser_msgs::msg::DispenserResult;
   using Pose3d = ignition::math::Pose3d;
@@ -81,12 +83,14 @@ public:
     auto status = msg->status;
     std::string source_guid = msg->source_guid.c_str();
 
-    if (source_guid == _load_guid && !_object_loaded) {
+    if (source_guid == _load_guid && !_object_loaded)
+    {
       RCLCPP_INFO(_node->get_logger(), "Loading object");
       _model->SetWorldPose(_load_pose);
       _object_loaded = true;
     }
-    else if (source_guid == _unload_guid && _object_loaded) {
+    else if (source_guid == _unload_guid && _object_loaded)
+    {
       RCLCPP_INFO(_node->get_logger(), "Unloading object");
       _model->SetWorldPose(_unload_pose);
 
@@ -97,14 +101,16 @@ public:
       _model->SetWorldPose(_initial_pose);
       _object_loaded = false;
     }
-    else {
+    else
+    {
       return;
     }
   }
 
   ~TeleportPlugin()
   {
-    if (_load_complete) {
+    if (_load_complete)
+    {
       rclcpp::shutdown();
     }
   }

--- a/rmf_gazebo_plugins/src/teleport.cpp
+++ b/rmf_gazebo_plugins/src/teleport.cpp
@@ -50,7 +50,8 @@ public:
 
   bool _object_loaded = false;
 
-  void Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf) override {
+  void Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf) override
+  {
     // Store the pointer to the model
     _model = _parent;
 
@@ -75,7 +76,8 @@ public:
   }
 
   // Called by the world update start event
-  void dispenser_result_cb(DispenserResult::UniquePtr msg) {
+  void dispenser_result_cb(DispenserResult::UniquePtr msg)
+  {
     auto status = msg->status;
     std::string source_guid = msg->source_guid.c_str();
 
@@ -83,7 +85,8 @@ public:
       RCLCPP_INFO(_node->get_logger(), "Loading object");
       _model->SetWorldPose(_load_pose);
       _object_loaded = true;
-    } else if (source_guid == _unload_guid && _object_loaded) {
+    }
+    else if (source_guid == _unload_guid && _object_loaded) {
       RCLCPP_INFO(_node->get_logger(), "Unloading object");
       _model->SetWorldPose(_unload_pose);
 
@@ -93,13 +96,14 @@ public:
       rclcpp::sleep_for(std::chrono::nanoseconds(3000000000));
       _model->SetWorldPose(_initial_pose);
       _object_loaded = false;
-
-    } else {
+    }
+    else {
       return;
     }
   }
 
-  ~TeleportPlugin() {
+  ~TeleportPlugin()
+  {
     if (_load_complete) {
       rclcpp::shutdown();
     }

--- a/rmf_gazebo_plugins/src/utils.cpp
+++ b/rmf_gazebo_plugins/src/utils.cpp
@@ -7,8 +7,7 @@ namespace rmf_gazebo_plugins
 {
 
 //==============================================================================
-double compute_ds(double s_target, double v_actual, const double v_max,
-                  const double accel_nom, const double accel_max,
+double compute_ds(double s_target, double v_actual, const double v_max, const double accel_nom, const double accel_max,
                   const double dt)
 {
   double sign = 1.0;
@@ -36,7 +35,7 @@ double compute_ds(double s_target, double v_actual, const double v_max,
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
     double deceleration = pow(v_actual, 2) / s_target;
-    deceleration = std::min(deceleration, accel_max);
+    deceleration        = std::min(deceleration, accel_max);
 
     if (accel_nom <= deceleration)
     {
@@ -51,8 +50,7 @@ double compute_ds(double s_target, double v_actual, const double v_max,
 }
 
 //==============================================================================
-double compute_desired_rate_of_change(double _s_target, double _v_actual,
-                                      const MotionParams &_motion_params,
+double compute_desired_rate_of_change(double _s_target, double _v_actual, const MotionParams &_motion_params,
                                       const double _dt)
 {
   double sign = 1.0;
@@ -79,7 +77,7 @@ double compute_desired_rate_of_change(double _s_target, double _v_actual,
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
     double deceleration = pow(_v_actual, 2) / (2.0 * _s_target);
-    deceleration = std::min(deceleration, _motion_params.a_max);
+    deceleration        = std::min(deceleration, _motion_params.a_max);
 
     if (_motion_params.a_nom <= deceleration)
     {
@@ -96,9 +94,7 @@ double compute_desired_rate_of_change(double _s_target, double _v_actual,
 }
 
 //==============================================================================
-bool get_element_required(const sdf::ElementPtr &_sdf,
-                          const std::string &_element_name,
-                          sdf::ElementPtr &_element)
+bool get_element_required(const sdf::ElementPtr &_sdf, const std::string &_element_name, sdf::ElementPtr &_element)
 {
   if (!_sdf->HasElement(_element_name))
   {

--- a/rmf_gazebo_plugins/src/utils.cpp
+++ b/rmf_gazebo_plugins/src/utils.cpp
@@ -1,22 +1,17 @@
-#include <cmath>
 #include <algorithm>
+#include <cmath>
 
 #include "utils.hpp"
 
 namespace rmf_gazebo_plugins {
 
 //==============================================================================
-double compute_ds(
-    double s_target,
-    double v_actual,
-    const double v_max,
-    const double accel_nom,
-    const double accel_max,
-    const double dt)
+double compute_ds(double s_target, double v_actual, const double v_max,
+                  const double accel_nom, const double accel_max,
+                  const double dt)
 {
   double sign = 1.0;
-  if (s_target < 0.0)
-  {
+  if (s_target < 0.0) {
     // Limits get confusing when we need to go backwards, so we'll flip signs
     // here so that we pretend the target is forwards
     s_target *= -1.0;
@@ -24,7 +19,8 @@ double compute_ds(
     sign = -1.0;
   }
 
-  // We should try not to shoot past the targstd::vector<event::ConnectionPtr> connections;et
+  // We should try not to shoot past the targstd::vector<event::ConnectionPtr>
+  // connections;et
   double next_s = s_target / dt;
 
   // Test velocity limit
@@ -33,15 +29,13 @@ double compute_ds(
   // Test acceleration limit
   next_s = std::min(next_s, accel_nom * dt + v_actual);
 
-  if (v_actual > 0.0 && s_target > 0.0)
-  {
+  if (v_actual > 0.0 && s_target > 0.0) {
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
     double deceleration = pow(v_actual, 2) / s_target;
     deceleration = std::min(deceleration, accel_max);
 
-    if (accel_nom <= deceleration)
-    {
+    if (accel_nom <= deceleration) {
       // If the smallest constant deceleration for reaching the goal is
       // greater than
       next_s = -deceleration * dt + v_actual;
@@ -53,11 +47,9 @@ double compute_ds(
 }
 
 //==============================================================================
-double compute_desired_rate_of_change(
-    double _s_target,
-    double _v_actual,
-    const MotionParams& _motion_params,
-    const double _dt)
+double compute_desired_rate_of_change(double _s_target, double _v_actual,
+                                      const MotionParams &_motion_params,
+                                      const double _dt)
 {
   double sign = 1.0;
   if (_s_target < 0.0) {
@@ -97,13 +89,11 @@ double compute_desired_rate_of_change(
 }
 
 //==============================================================================
-bool get_element_required(
-    const sdf::ElementPtr& _sdf,
-    const std::string& _element_name,
-    sdf::ElementPtr& _element)
+bool get_element_required(const sdf::ElementPtr &_sdf,
+                          const std::string &_element_name,
+                          sdf::ElementPtr &_element)
 {
-  if (!_sdf->HasElement(_element_name))
-  {
+  if (!_sdf->HasElement(_element_name)) {
     std::cerr << "Element [" << _element_name << "] not found" << std::endl;
     return false;
   }

--- a/rmf_gazebo_plugins/src/utils.cpp
+++ b/rmf_gazebo_plugins/src/utils.cpp
@@ -3,7 +3,8 @@
 
 #include "utils.hpp"
 
-namespace rmf_gazebo_plugins {
+namespace rmf_gazebo_plugins
+{
 
 //==============================================================================
 double compute_ds(double s_target, double v_actual, const double v_max,
@@ -11,7 +12,8 @@ double compute_ds(double s_target, double v_actual, const double v_max,
                   const double dt)
 {
   double sign = 1.0;
-  if (s_target < 0.0) {
+  if (s_target < 0.0)
+  {
     // Limits get confusing when we need to go backwards, so we'll flip signs
     // here so that we pretend the target is forwards
     s_target *= -1.0;
@@ -29,13 +31,15 @@ double compute_ds(double s_target, double v_actual, const double v_max,
   // Test acceleration limit
   next_s = std::min(next_s, accel_nom * dt + v_actual);
 
-  if (v_actual > 0.0 && s_target > 0.0) {
+  if (v_actual > 0.0 && s_target > 0.0)
+  {
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
     double deceleration = pow(v_actual, 2) / s_target;
     deceleration = std::min(deceleration, accel_max);
 
-    if (accel_nom <= deceleration) {
+    if (accel_nom <= deceleration)
+    {
       // If the smallest constant deceleration for reaching the goal is
       // greater than
       next_s = -deceleration * dt + v_actual;
@@ -52,7 +56,8 @@ double compute_desired_rate_of_change(double _s_target, double _v_actual,
                                       const double _dt)
 {
   double sign = 1.0;
-  if (_s_target < 0.0) {
+  if (_s_target < 0.0)
+  {
     // Limits get confusing when we need to go backwards, so we'll flip signs
     // here so that we pretend the target is forwards
     _s_target *= -1.0;
@@ -69,13 +74,15 @@ double compute_desired_rate_of_change(double _s_target, double _v_actual,
   // Test acceleration limit
   v_next = std::min(v_next, _motion_params.a_nom * _dt + _v_actual);
 
-  if (_v_actual > 0.0 && _s_target > 0.0) {
+  if (_v_actual > 0.0 && _s_target > 0.0)
+  {
     // This is what our deceleration should be if we want to begin a constant
     // deceleration from now until we reach the goal
     double deceleration = pow(_v_actual, 2) / (2.0 * _s_target);
     deceleration = std::min(deceleration, _motion_params.a_max);
 
-    if (_motion_params.a_nom <= deceleration) {
+    if (_motion_params.a_nom <= deceleration)
+    {
       // If the smallest constant deceleration for reaching the goal is
       // greater than the nominal acceleration, then we should begin
       // decelerating right away so that we can smoothly reach the goal while
@@ -93,7 +100,8 @@ bool get_element_required(const sdf::ElementPtr &_sdf,
                           const std::string &_element_name,
                           sdf::ElementPtr &_element)
 {
-  if (!_sdf->HasElement(_element_name)) {
+  if (!_sdf->HasElement(_element_name))
+  {
     std::cerr << "Element [" << _element_name << "] not found" << std::endl;
     return false;
   }

--- a/rmf_gazebo_plugins/src/utils.hpp
+++ b/rmf_gazebo_plugins/src/utils.hpp
@@ -8,43 +8,37 @@ namespace rmf_gazebo_plugins
 
 // TODO(MXG): Refactor the use of this function to replace it with
 // compute_desired_rate_of_change()
-double compute_ds(double s_target, double v_actual, double v_max,
-                  double accel_nom, double accel_max, double dt);
+double compute_ds(double s_target, double v_actual, double v_max, double accel_nom, double accel_max, double dt);
 
 struct MotionParams
 {
-  double v_max = 0.2;
-  double a_max = 0.1;
-  double a_nom = 0.08;
+  double v_max  = 0.2;
+  double a_max  = 0.1;
+  double a_nom  = 0.08;
   double dx_min = 0.01;
-  double f_max = 10000000.0;
+  double f_max  = 10000000.0;
 };
 
-double compute_desired_rate_of_change(double _s_target, double _v_actual,
-                                      const MotionParams &_motion_params,
+double compute_desired_rate_of_change(double _s_target, double _v_actual, const MotionParams &_motion_params,
                                       const double _dt);
 
-bool get_element_required(const sdf::ElementPtr &_sdf,
-                          const std::string &_element_name,
-                          sdf::ElementPtr &_element);
+bool get_element_required(const sdf::ElementPtr &_sdf, const std::string &_element_name, sdf::ElementPtr &_element);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-bool get_sdf_attribute_required(const sdf::ElementPtr &sdf,
-                                const std::string &attribute_name, T &value)
+bool get_sdf_attribute_required(const sdf::ElementPtr &sdf, const std::string &attribute_name, T &value)
 {
   if (sdf->HasAttribute(attribute_name))
   {
     if (sdf->GetAttribute(attribute_name)->Get(value))
     {
-      std::cout << "Using specified attribute value [" << value
-                << "] for property [" << attribute_name << "]" << std::endl;
+      std::cout << "Using specified attribute value [" << value << "] for property [" << attribute_name << "]"
+                << std::endl;
       return true;
     }
     else
     {
-      std::cerr << "Failed to parse sdf attribute for [" << attribute_name
-                << "]" << std::endl;
+      std::cerr << "Failed to parse sdf attribute for [" << attribute_name << "]" << std::endl;
     }
   }
   else
@@ -57,21 +51,18 @@ bool get_sdf_attribute_required(const sdf::ElementPtr &sdf,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-bool get_sdf_param_required(const sdf::ElementPtr &sdf,
-                            const std::string &parameter_name, T &value)
+bool get_sdf_param_required(const sdf::ElementPtr &sdf, const std::string &parameter_name, T &value)
 {
   if (sdf->HasElement(parameter_name))
   {
     if (sdf->GetElement(parameter_name)->GetValue()->Get(value))
     {
-      std::cout << "Using specified value [" << value << "] for property ["
-                << parameter_name << "]" << std::endl;
+      std::cout << "Using specified value [" << value << "] for property [" << parameter_name << "]" << std::endl;
       return true;
     }
     else
     {
-      std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
-                << std::endl;
+      std::cerr << "Failed to parse sdf value for [" << parameter_name << "]" << std::endl;
     }
   }
   else
@@ -84,26 +75,22 @@ bool get_sdf_param_required(const sdf::ElementPtr &sdf,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void get_sdf_param_if_available(const sdf::ElementPtr &sdf,
-                                const std::string &parameter_name, T &value)
+void get_sdf_param_if_available(const sdf::ElementPtr &sdf, const std::string &parameter_name, T &value)
 {
   if (sdf->HasElement(parameter_name))
   {
     if (sdf->GetElement(parameter_name)->GetValue()->Get(value))
     {
-      std::cout << "Using specified value [" << value << "] for property ["
-                << parameter_name << "]" << std::endl;
+      std::cout << "Using specified value [" << value << "] for property [" << parameter_name << "]" << std::endl;
     }
     else
     {
-      std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
-                << std::endl;
+      std::cerr << "Failed to parse sdf value for [" << parameter_name << "]" << std::endl;
     }
   }
   else
   {
-    std::cout << "Using default value [" << value << "] for property ["
-              << parameter_name << "]" << std::endl;
+    std::cout << "Using default value [" << value << "] for property [" << parameter_name << "]" << std::endl;
   }
 }
 

--- a/rmf_gazebo_plugins/src/utils.hpp
+++ b/rmf_gazebo_plugins/src/utils.hpp
@@ -7,16 +7,10 @@ namespace rmf_gazebo_plugins {
 
 // TODO(MXG): Refactor the use of this function to replace it with
 // compute_desired_rate_of_change()
-double compute_ds(
-    double s_target,
-    double v_actual,
-    double v_max,
-    double accel_nom,
-    double accel_max,
-    double dt);
+double compute_ds(double s_target, double v_actual, double v_max,
+                  double accel_nom, double accel_max, double dt);
 
-struct MotionParams
-{
+struct MotionParams {
   double v_max = 0.2;
   double a_max = 0.1;
   double a_nom = 0.08;
@@ -24,38 +18,31 @@ struct MotionParams
   double f_max = 10000000.0;
 };
 
-double compute_desired_rate_of_change(
-    double _s_target,
-    double _v_actual,
-    const MotionParams& _motion_params,
-    const double _dt);
+double compute_desired_rate_of_change(double _s_target, double _v_actual,
+                                      const MotionParams &_motion_params,
+                                      const double _dt);
 
-bool get_element_required(
-    const sdf::ElementPtr& _sdf,
-    const std::string& _element_name,
-    sdf::ElementPtr& _element);
+bool get_element_required(const sdf::ElementPtr &_sdf,
+                          const std::string &_element_name,
+                          sdf::ElementPtr &_element);
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename T>
-bool get_sdf_attribute_required(const sdf::ElementPtr& sdf, const std::string& attribute_name, T& value)
+template <typename T>
+bool get_sdf_attribute_required(const sdf::ElementPtr &sdf,
+                                const std::string &attribute_name, T &value)
 {
-  if(sdf->HasAttribute(attribute_name))
-  {
-    if(sdf->GetAttribute(attribute_name)->Get(value))
-    {
+  if (sdf->HasAttribute(attribute_name)) {
+    if (sdf->GetAttribute(attribute_name)->Get(value)) {
       std::cout << "Using specified attribute value [" << value
-                      << "] for property [" << attribute_name << "]"
-                      << std::endl;
+                << "] for property [" << attribute_name << "]" << std::endl;
       return true;
     }
-    else
-    {
+    else {
       std::cerr << "Failed to parse sdf attribute for [" << attribute_name
                 << "]" << std::endl;
     }
   }
-  else
-  {
+  else {
     std::cerr << "Attribute [" << attribute_name << "] not found" << std::endl;
   }
 
@@ -63,25 +50,22 @@ bool get_sdf_attribute_required(const sdf::ElementPtr& sdf, const std::string& a
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename T>
-bool get_sdf_param_required(const sdf::ElementPtr& sdf, const std::string& parameter_name, T& value)
+template <typename T>
+bool get_sdf_param_required(const sdf::ElementPtr &sdf,
+                            const std::string &parameter_name, T &value)
 {
-  if(sdf->HasElement(parameter_name))
-  {
-    if(sdf->GetElement(parameter_name)->GetValue()->Get(value))
-    {
+  if (sdf->HasElement(parameter_name)) {
+    if (sdf->GetElement(parameter_name)->GetValue()->Get(value)) {
       std::cout << "Using specified value [" << value << "] for property ["
-                      << parameter_name << "]" << std::endl;
+                << parameter_name << "]" << std::endl;
       return true;
     }
-    else
-    {
+    else {
       std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
-                <<std::endl;
+                << std::endl;
     }
   }
-  else
-  {
+  else {
     std::cerr << "Property [" << parameter_name << "] not found" << std::endl;
   }
 
@@ -89,26 +73,23 @@ bool get_sdf_param_required(const sdf::ElementPtr& sdf, const std::string& param
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-template<typename T>
-void get_sdf_param_if_available(const sdf::ElementPtr& sdf, const std::string& parameter_name, T& value)
+template <typename T>
+void get_sdf_param_if_available(const sdf::ElementPtr &sdf,
+                                const std::string &parameter_name, T &value)
 {
-  if(sdf->HasElement(parameter_name))
-  {
-    if(sdf->GetElement(parameter_name)->GetValue()->Get(value))
-    {
+  if (sdf->HasElement(parameter_name)) {
+    if (sdf->GetElement(parameter_name)->GetValue()->Get(value)) {
       std::cout << "Using specified value [" << value << "] for property ["
-                      << parameter_name << "]" << std::endl;
+                << parameter_name << "]" << std::endl;
     }
-    else
-    {
-      std::cerr << "Failed to parse sdf value for [" << parameter_name
-                << "]" << std::endl;
+    else {
+      std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
+                << std::endl;
     }
   }
-  else
-  {
+  else {
     std::cout << "Using default value [" << value << "] for property ["
-                    << parameter_name << "]" << std::endl;
+              << parameter_name << "]" << std::endl;
   }
 }
 

--- a/rmf_gazebo_plugins/src/utils.hpp
+++ b/rmf_gazebo_plugins/src/utils.hpp
@@ -3,14 +3,16 @@
 
 #include <sdf/Element.hh>
 
-namespace rmf_gazebo_plugins {
+namespace rmf_gazebo_plugins
+{
 
 // TODO(MXG): Refactor the use of this function to replace it with
 // compute_desired_rate_of_change()
 double compute_ds(double s_target, double v_actual, double v_max,
                   double accel_nom, double accel_max, double dt);
 
-struct MotionParams {
+struct MotionParams
+{
   double v_max = 0.2;
   double a_max = 0.1;
   double a_nom = 0.08;
@@ -31,18 +33,22 @@ template <typename T>
 bool get_sdf_attribute_required(const sdf::ElementPtr &sdf,
                                 const std::string &attribute_name, T &value)
 {
-  if (sdf->HasAttribute(attribute_name)) {
-    if (sdf->GetAttribute(attribute_name)->Get(value)) {
+  if (sdf->HasAttribute(attribute_name))
+  {
+    if (sdf->GetAttribute(attribute_name)->Get(value))
+    {
       std::cout << "Using specified attribute value [" << value
                 << "] for property [" << attribute_name << "]" << std::endl;
       return true;
     }
-    else {
+    else
+    {
       std::cerr << "Failed to parse sdf attribute for [" << attribute_name
                 << "]" << std::endl;
     }
   }
-  else {
+  else
+  {
     std::cerr << "Attribute [" << attribute_name << "] not found" << std::endl;
   }
 
@@ -54,18 +60,22 @@ template <typename T>
 bool get_sdf_param_required(const sdf::ElementPtr &sdf,
                             const std::string &parameter_name, T &value)
 {
-  if (sdf->HasElement(parameter_name)) {
-    if (sdf->GetElement(parameter_name)->GetValue()->Get(value)) {
+  if (sdf->HasElement(parameter_name))
+  {
+    if (sdf->GetElement(parameter_name)->GetValue()->Get(value))
+    {
       std::cout << "Using specified value [" << value << "] for property ["
                 << parameter_name << "]" << std::endl;
       return true;
     }
-    else {
+    else
+    {
       std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
                 << std::endl;
     }
   }
-  else {
+  else
+  {
     std::cerr << "Property [" << parameter_name << "] not found" << std::endl;
   }
 
@@ -77,17 +87,21 @@ template <typename T>
 void get_sdf_param_if_available(const sdf::ElementPtr &sdf,
                                 const std::string &parameter_name, T &value)
 {
-  if (sdf->HasElement(parameter_name)) {
-    if (sdf->GetElement(parameter_name)->GetValue()->Get(value)) {
+  if (sdf->HasElement(parameter_name))
+  {
+    if (sdf->GetElement(parameter_name)->GetValue()->Get(value))
+    {
       std::cout << "Using specified value [" << value << "] for property ["
                 << parameter_name << "]" << std::endl;
     }
-    else {
+    else
+    {
       std::cerr << "Failed to parse sdf value for [" << parameter_name << "]"
                 << std::endl;
     }
   }
-  else {
+  else
+  {
     std::cout << "Using default value [" << value << "] for property ["
               << parameter_name << "]" << std::endl;
   }

--- a/rmf_rviz_plugin/src/RmfPanel.cpp
+++ b/rmf_rviz_plugin/src/RmfPanel.cpp
@@ -23,397 +23,400 @@
 #include <QGroupBox>
 #include <QGridLayout>
 
-namespace rmf_rviz_plugin {
-
-void RmfPanel::create_layout()
+namespace rmf_rviz_plugin
 {
-  // Layout for delivery request
-  QGridLayout* layout_delivery = new QGridLayout(this);
 
-  // Row 1
-  layout_delivery->addWidget(new QLabel("Task ID:"), 0, 0);
-  _delivery_task_id_editor = new QLineEdit;
-  _delivery_task_id_editor->setFixedWidth(150);
-  layout_delivery->addWidget(_delivery_task_id_editor,0, 1);
-
-  layout_delivery->addWidget(new QLabel("Robot:"), 0, 2);
-  _delivery_robot_editor = new QLineEdit;
-  _delivery_robot_editor->setFixedWidth(150);
-  layout_delivery->addWidget(_delivery_robot_editor, 0, 3);
-
-  // Row 2
-  layout_delivery->addWidget(new QLabel("Pickup:"), 1, 0);
-  _delivery_pickup_editor = new QLineEdit;
-  _delivery_pickup_editor->setFixedWidth(150);
-  layout_delivery->addWidget(_delivery_pickup_editor, 1, 1);
-
-  layout_delivery->addWidget(new QLabel("Dropoff:"), 1, 2);
-  _delivery_dropoff_editor = new QLineEdit;
-  _delivery_dropoff_editor->setFixedWidth(150);
-  layout_delivery->addWidget(_delivery_dropoff_editor, 1, 3);
-
-  // Row 3
-  _delivery_button = new QPushButton(this);
-  _delivery_button->setText("Request Delivery");
-  layout_delivery->addWidget(_delivery_button, 2, 1, 1, 2);
-
-  // Creating box for delivery request
-  QGroupBox* delivery_box = new QGroupBox("Delivery Request");
-  delivery_box->setLayout(layout_delivery);
-
-  // Layout for loop request
-  // Row 1
-  QGridLayout* layout_loop = new QGridLayout(this);
-  layout_loop->addWidget(new QLabel("Task ID:"), 0, 0);
-  _loop_task_id_editor = new QLineEdit;
-  _loop_task_id_editor->setFixedWidth(150);
-  layout_loop->addWidget(_loop_task_id_editor, 0 , 1);
-
-  layout_loop->addWidget(new QLabel("Robot:"), 0, 2);
-  _loop_robot_editor = new QLineEdit;
-  _loop_robot_editor->setFixedWidth(150);
-  layout_loop->addWidget(_loop_robot_editor, 0, 3);
-
-  // Row 2
-  layout_loop->addWidget(new QLabel("Start:"), 1, 0);
-  _loop_start_editor = new QLineEdit;
-  _loop_start_editor->setFixedWidth(150);
-  layout_loop->addWidget(_loop_start_editor, 1, 1);
-
-  layout_loop->addWidget(new QLabel("Finish:"), 1, 2);
-  _loop_finish_editor = new QLineEdit;
-  _loop_finish_editor->setFixedWidth(150);
-  layout_loop->addWidget(_loop_finish_editor, 1, 3);
-
-  // Row 3
-  layout_loop->addWidget(new QLabel("Loops:"), 2, 0);
-  _loop_num_editor = new QLineEdit;
-  _loop_num_editor->setFixedWidth(100);
-  layout_loop->addWidget(_loop_num_editor, 2, 1);
-
-  // Row 4
-  _loop_button = new QPushButton(this);
-  _loop_button->setText("Request Loop");
-  layout_loop->addWidget(_loop_button, 3, 1, 1, 2);
-
-  // Creating box for loop request
-  QGroupBox* loop_box = new QGroupBox("Loop Request");
-  loop_box->setLayout(layout_loop);
-
-  // Combining layouts into a single vertical layout
-  QVBoxLayout* layout = new QVBoxLayout;
-  layout->addStretch();
-  layout->addWidget(loop_box);
-  layout->addWidget(delivery_box);
-  setLayout(layout);
-
-  // Initialize text fields
-  _delivery_task_id_editor->setText(_delivery_task_id);
-  _delivery_pickup_editor->setText(_delivery_pickup);
-  _delivery_dropoff_editor->setText(_delivery_dropoff);
-  _delivery_robot_editor->setText(_delivery_robot);
-
-  _loop_task_id_editor->setText(_loop_task_id);
-  _loop_start_editor->setText(_loop_start);
-  _loop_finish_editor->setText(_loop_finish);
-  _loop_robot_editor->setText(_loop_robot);
-  _loop_num_editor->setText(_loop_num);
-
-  // QT signal connections
-  connect(_delivery_task_id_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_delivery_task_id()));
-  connect(_delivery_robot_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_delivery_robot()));
-  connect(_delivery_pickup_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_delivery_pickup()));
-  connect(_delivery_dropoff_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_delivery_dropoff()));
-  connect(_delivery_button,
-      SIGNAL(clicked()), this, SLOT(request_delivery()));
-
-  connect(_loop_task_id_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_loop_task_id()));
-  connect(_loop_robot_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_loop_robot()));
-  connect(_loop_start_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_loop_start()));
-  connect(_loop_finish_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_loop_finish()));
-  connect(_loop_num_editor,
-      SIGNAL(editingFinished()), this, SLOT(update_loop_num()));
-  connect(_loop_button,
-      SIGNAL(clicked()), this, SLOT(request_loop()));
-}
-
-RmfPanel::RmfPanel(QWidget* parent)
-: rviz_common::Panel(parent),
-  _delivery_task_id("task#42"),
-  _delivery_robot("magni"),
-  _delivery_pickup("pantry"),
-  _delivery_dropoff("hardware_2"),
-  _loop_task_id("task#24"),
-  _loop_robot("magni"),
-  _loop_start("coe"),
-  _loop_finish("cubicle_1"),
-  _loop_num("1")
-{
-  _node = std::make_shared<rclcpp::Node>("rmf_panel_plugin");
-
-  _delivery_pub = _node->create_publisher<Delivery>(
-    "/delivery_requests",
-    rclcpp::QoS(10));
-
-  _loop_pub = _node->create_publisher<Loop>(
-    "/loop_requests",
-    rclcpp::QoS(10));
-
-  _thread = std::thread([&](){rclcpp::spin(_node);});
-  
-  create_layout();
-  _has_loaded = true;
-}
-
-RmfPanel::~RmfPanel()
-{
-  if (_has_loaded)
+  void RmfPanel::create_layout ()
   {
-    _thread.join();
-    rclcpp::shutdown();
+    // Layout for delivery request
+    QGridLayout *layout_delivery = new QGridLayout (this);
+
+    // Row 1
+      layout_delivery->addWidget (new QLabel ("Task ID:"), 0, 0);
+      _delivery_task_id_editor = new QLineEdit;
+      _delivery_task_id_editor->setFixedWidth (150);
+      layout_delivery->addWidget (_delivery_task_id_editor, 0, 1);
+
+      layout_delivery->addWidget (new QLabel ("Robot:"), 0, 2);
+      _delivery_robot_editor = new QLineEdit;
+      _delivery_robot_editor->setFixedWidth (150);
+      layout_delivery->addWidget (_delivery_robot_editor, 0, 3);
+
+    // Row 2
+      layout_delivery->addWidget (new QLabel ("Pickup:"), 1, 0);
+      _delivery_pickup_editor = new QLineEdit;
+      _delivery_pickup_editor->setFixedWidth (150);
+      layout_delivery->addWidget (_delivery_pickup_editor, 1, 1);
+
+      layout_delivery->addWidget (new QLabel ("Dropoff:"), 1, 2);
+      _delivery_dropoff_editor = new QLineEdit;
+      _delivery_dropoff_editor->setFixedWidth (150);
+      layout_delivery->addWidget (_delivery_dropoff_editor, 1, 3);
+
+    // Row 3
+      _delivery_button = new QPushButton (this);
+      _delivery_button->setText ("Request Delivery");
+      layout_delivery->addWidget (_delivery_button, 2, 1, 1, 2);
+
+    // Creating box for delivery request
+    QGroupBox *delivery_box = new QGroupBox ("Delivery Request");
+      delivery_box->setLayout (layout_delivery);
+
+    // Layout for loop request
+    // Row 1
+    QGridLayout *layout_loop = new QGridLayout (this);
+      layout_loop->addWidget (new QLabel ("Task ID:"), 0, 0);
+      _loop_task_id_editor = new QLineEdit;
+      _loop_task_id_editor->setFixedWidth (150);
+      layout_loop->addWidget (_loop_task_id_editor, 0, 1);
+
+      layout_loop->addWidget (new QLabel ("Robot:"), 0, 2);
+      _loop_robot_editor = new QLineEdit;
+      _loop_robot_editor->setFixedWidth (150);
+      layout_loop->addWidget (_loop_robot_editor, 0, 3);
+
+    // Row 2
+      layout_loop->addWidget (new QLabel ("Start:"), 1, 0);
+      _loop_start_editor = new QLineEdit;
+      _loop_start_editor->setFixedWidth (150);
+      layout_loop->addWidget (_loop_start_editor, 1, 1);
+
+      layout_loop->addWidget (new QLabel ("Finish:"), 1, 2);
+      _loop_finish_editor = new QLineEdit;
+      _loop_finish_editor->setFixedWidth (150);
+      layout_loop->addWidget (_loop_finish_editor, 1, 3);
+
+    // Row 3
+      layout_loop->addWidget (new QLabel ("Loops:"), 2, 0);
+      _loop_num_editor = new QLineEdit;
+      _loop_num_editor->setFixedWidth (100);
+      layout_loop->addWidget (_loop_num_editor, 2, 1);
+
+    // Row 4
+      _loop_button = new QPushButton (this);
+      _loop_button->setText ("Request Loop");
+      layout_loop->addWidget (_loop_button, 3, 1, 1, 2);
+
+    // Creating box for loop request
+    QGroupBox *loop_box = new QGroupBox ("Loop Request");
+      loop_box->setLayout (layout_loop);
+
+    // Combining layouts into a single vertical layout
+    QVBoxLayout *layout = new QVBoxLayout;
+      layout->addStretch ();
+      layout->addWidget (loop_box);
+      layout->addWidget (delivery_box);
+      setLayout (layout);
+
+    // Initialize text fields
+      _delivery_task_id_editor->setText (_delivery_task_id);
+      _delivery_pickup_editor->setText (_delivery_pickup);
+      _delivery_dropoff_editor->setText (_delivery_dropoff);
+      _delivery_robot_editor->setText (_delivery_robot);
+
+      _loop_task_id_editor->setText (_loop_task_id);
+      _loop_start_editor->setText (_loop_start);
+      _loop_finish_editor->setText (_loop_finish);
+      _loop_robot_editor->setText (_loop_robot);
+      _loop_num_editor->setText (_loop_num);
+
+    // QT signal connections
+      connect (_delivery_task_id_editor,
+               SIGNAL (editingFinished ()), this,
+               SLOT (update_delivery_task_id ()));
+      connect (_delivery_robot_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_delivery_robot ()));
+      connect (_delivery_pickup_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_delivery_pickup ()));
+      connect (_delivery_dropoff_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_delivery_dropoff ()));
+      connect (_delivery_button, SIGNAL (clicked ()), this,
+               SLOT (request_delivery ()));
+
+      connect (_loop_task_id_editor,
+               SIGNAL (editingFinished ()), this,
+               SLOT (update_loop_task_id ()));
+      connect (_loop_robot_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_loop_robot ()));
+      connect (_loop_start_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_loop_start ()));
+      connect (_loop_finish_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_loop_finish ()));
+      connect (_loop_num_editor, SIGNAL (editingFinished ()), this,
+               SLOT (update_loop_num ()));
+      connect (_loop_button, SIGNAL (clicked ()), this,
+               SLOT (request_loop ()));
   }
-}
+
+  RmfPanel::RmfPanel (QWidget * parent):rviz_common::Panel (parent),
+    _delivery_task_id ("task#42"),
+    _delivery_robot ("magni"),
+    _delivery_pickup ("pantry"),
+    _delivery_dropoff ("hardware_2"),
+    _loop_task_id ("task#24"),
+    _loop_robot ("magni"),
+    _loop_start ("coe"), _loop_finish ("cubicle_1"), _loop_num ("1")
+  {
+    _node = std::make_shared < rclcpp::Node > ("rmf_panel_plugin");
+
+    _delivery_pub =
+      _node->create_publisher < Delivery > ("/delivery_requests",
+                                            rclcpp::QoS (10));
+
+    _loop_pub = _node->create_publisher < Loop > ("/loop_requests",
+                                                  rclcpp::QoS (10));
+
+    _thread = std::thread ([&]()
+                           {
+                           rclcpp::spin (_node);
+                           });
+
+    create_layout ();
+    _has_loaded = true;
+  }
+
+  RmfPanel::~RmfPanel ()
+  {
+    if (_has_loaded)
+      {
+        _thread.join ();
+        rclcpp::shutdown ();
+      }
+  }
 
 // Delivery set functions 
-void RmfPanel::set_delivery_task_id(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _delivery_task_id = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_delivery_task_id (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _delivery_task_id = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_delivery_pickup(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _delivery_pickup = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_delivery_pickup (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _delivery_pickup = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_delivery_dropoff(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _delivery_dropoff = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_delivery_dropoff (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _delivery_dropoff = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_delivery_robot(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _delivery_robot = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_delivery_robot (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _delivery_robot = value;
+    Q_EMIT configChanged ();
+  }
 
 // Loop set functions
-void RmfPanel::set_loop_task_id(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_task_id = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_loop_task_id (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_task_id = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_loop_start(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_start = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_loop_start (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_start = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_loop_finish(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_finish = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_loop_finish (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_finish = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_loop_robot(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_robot = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_loop_robot (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_robot = value;
+    Q_EMIT configChanged ();
+  }
 
-void RmfPanel::set_loop_num(const QString& value)
-{
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_num = value;
-  Q_EMIT configChanged();
-}
+  void RmfPanel::set_loop_num (const QString & value)
+  {
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_num = value;
+    Q_EMIT configChanged ();
+  }
 
 // Delivery update functions 
-void RmfPanel::update_delivery_task_id()
-{
-  set_delivery_task_id(_delivery_task_id_editor->text());
-}
+  void RmfPanel::update_delivery_task_id ()
+  {
+    set_delivery_task_id (_delivery_task_id_editor->text ());
+  }
 
-void RmfPanel::update_delivery_pickup()
-{
-  set_delivery_pickup(_delivery_pickup_editor->text());
-}
+  void RmfPanel::update_delivery_pickup ()
+  {
+    set_delivery_pickup (_delivery_pickup_editor->text ());
+  }
 
-void RmfPanel::update_delivery_dropoff()
-{
-  set_delivery_dropoff(_delivery_dropoff_editor->text());
-}
+  void RmfPanel::update_delivery_dropoff ()
+  {
+    set_delivery_dropoff (_delivery_dropoff_editor->text ());
+  }
 
-void RmfPanel::update_delivery_robot()
-{
-  set_delivery_robot(_delivery_robot_editor->text());
-}
+  void RmfPanel::update_delivery_robot ()
+  {
+    set_delivery_robot (_delivery_robot_editor->text ());
+  }
 
 // Loop update functions
-void RmfPanel::update_loop_task_id()
-{
-  set_loop_task_id(_loop_task_id_editor->text());
-}
+  void RmfPanel::update_loop_task_id ()
+  {
+    set_loop_task_id (_loop_task_id_editor->text ());
+  }
 
-void RmfPanel::update_loop_start()
-{
-  set_loop_start(_loop_start_editor->text());
-}
+  void RmfPanel::update_loop_start ()
+  {
+    set_loop_start (_loop_start_editor->text ());
+  }
 
-void RmfPanel::update_loop_finish()
-{
-  set_loop_finish(_loop_finish_editor->text());
-}
+  void RmfPanel::update_loop_finish ()
+  {
+    set_loop_finish (_loop_finish_editor->text ());
+  }
 
-void RmfPanel::update_loop_robot()
-{
-  set_loop_robot(_loop_robot_editor->text());
-}
+  void RmfPanel::update_loop_robot ()
+  {
+    set_loop_robot (_loop_robot_editor->text ());
+  }
 
-void RmfPanel::update_loop_num()
-{
-  set_loop_num(_loop_num_editor->text());
-}
+  void RmfPanel::update_loop_num ()
+  {
+    set_loop_num (_loop_num_editor->text ());
+  }
 
 // Publisher functions
-void RmfPanel::request_delivery()
-{
-  Delivery delivery;
+  void RmfPanel::request_delivery ()
+  {
+    Delivery delivery;
 
-  std::lock_guard<std::mutex> lock(_mutex);
-  _delivery_task_id = _delivery_task_id == "" ? "task#42" : _delivery_task_id;
+    std::lock_guard < std::mutex > lock (_mutex);
+    _delivery_task_id =
+      _delivery_task_id == "" ? "task#42" : _delivery_task_id;
 
-  delivery.task_id = _delivery_task_id.toStdString();
-  delivery.pickup_place_name = _delivery_pickup.toStdString();
-  delivery.dropoff_place_name = _delivery_dropoff.toStdString();
+    delivery.task_id = _delivery_task_id.toStdString ();
+    delivery.pickup_place_name = _delivery_pickup.toStdString ();
+    delivery.dropoff_place_name = _delivery_dropoff.toStdString ();
 
-  _delivery_pub->publish(delivery);
-  RCLCPP_INFO(_node->get_logger(), "Published delivery request");
-}
+    _delivery_pub->publish (delivery);
+    RCLCPP_INFO (_node->get_logger (), "Published delivery request");
+  }
 
-void RmfPanel::request_loop()
-{
-  Loop loop;
+  void RmfPanel::request_loop ()
+  {
+    Loop loop;
 
-  std::lock_guard<std::mutex> lock(_mutex);
-  _loop_task_id = _loop_task_id == "" ? "task#24" : _loop_task_id;
+    std::lock_guard < std::mutex > lock (_mutex);
+    _loop_task_id = _loop_task_id == "" ? "task#24" : _loop_task_id;
 
-  loop.task_id = _loop_task_id.toStdString();
-  loop.robot_type = _loop_robot.toStdString();
-  loop.num_loops = _loop_num.toUInt();
-  loop.start_name = _loop_start.toStdString();
-  loop.finish_name = _loop_finish.toStdString();
+    loop.task_id = _loop_task_id.toStdString ();
+    loop.robot_type = _loop_robot.toStdString ();
+    loop.num_loops = _loop_num.toUInt ();
+    loop.start_name = _loop_start.toStdString ();
+    loop.finish_name = _loop_finish.toStdString ();
 
-  _loop_pub->publish(loop);
-  RCLCPP_INFO(_node->get_logger(), "Published loop request");
-}
+    _loop_pub->publish (loop);
+    RCLCPP_INFO (_node->get_logger (), "Published loop request");
+  }
 
 // Load config
-void RmfPanel::load(const rviz_common::Config& config)
-{
-  rviz_common::Panel::load(config);
-  QString delivery_task_id;
-  QString delivery_robot;
-  QString delivery_pickup;
-  QString delivery_dropoff;
-
-  QString loop_task_id;
-  QString loop_robot;
-  QString loop_start;
-  QString loop_finish;
-  QString loop_num;
-
-  if (config.mapGetString("delivery_task_id", &delivery_task_id))
+  void RmfPanel::load (const rviz_common::Config & config)
   {
-    _delivery_task_id_editor->setText(delivery_task_id);
-    update_delivery_task_id();
-  }
+    rviz_common::Panel::load (config);
+    QString delivery_task_id;
+    QString delivery_robot;
+    QString delivery_pickup;
+    QString delivery_dropoff;
 
-  if (config.mapGetString("delivery_robot", &delivery_robot))
-  {
-    _delivery_robot_editor->setText(delivery_robot);
-    update_delivery_robot();
-  }
+    QString loop_task_id;
+    QString loop_robot;
+    QString loop_start;
+    QString loop_finish;
+    QString loop_num;
 
-  if (config.mapGetString("delivery_pickup", &delivery_pickup))
-  {
-    _delivery_pickup_editor->setText(delivery_pickup);
-    update_delivery_pickup();
-  }
+    if (config.mapGetString ("delivery_task_id", &delivery_task_id))
+      {
+        _delivery_task_id_editor->setText (delivery_task_id);
+        update_delivery_task_id ();
+      }
 
-  if (config.mapGetString("delivery_dropoff", &delivery_dropoff))
-  {
-    _delivery_dropoff_editor->setText(delivery_dropoff);
-    update_delivery_dropoff();
-  }
+    if (config.mapGetString ("delivery_robot", &delivery_robot))
+      {
+        _delivery_robot_editor->setText (delivery_robot);
+        update_delivery_robot ();
+      }
 
-  if (config.mapGetString("loop_task_id", &loop_task_id))
-  {
-    _loop_task_id_editor->setText(loop_task_id);
-    update_loop_task_id();
-  }
+    if (config.mapGetString ("delivery_pickup", &delivery_pickup))
+      {
+        _delivery_pickup_editor->setText (delivery_pickup);
+        update_delivery_pickup ();
+      }
 
-  if (config.mapGetString("loop_robot", &loop_robot))
-  {
-    _loop_robot_editor->setText(loop_robot);
-    update_loop_robot();
-  }
+    if (config.mapGetString ("delivery_dropoff", &delivery_dropoff))
+      {
+        _delivery_dropoff_editor->setText (delivery_dropoff);
+        update_delivery_dropoff ();
+      }
 
-  if (config.mapGetString("loop_start", &loop_start))
-  {
-    _loop_start_editor->setText(loop_start);
-    update_loop_start();
-  }
+    if (config.mapGetString ("loop_task_id", &loop_task_id))
+      {
+        _loop_task_id_editor->setText (loop_task_id);
+        update_loop_task_id ();
+      }
 
-  if (config.mapGetString("loop_finish", &loop_finish))
-  {
-    _loop_finish_editor->setText(loop_finish);
-    update_loop_finish();
-  }
+    if (config.mapGetString ("loop_robot", &loop_robot))
+      {
+        _loop_robot_editor->setText (loop_robot);
+        update_loop_robot ();
+      }
 
-  if (config.mapGetString("loop_num", &loop_num))
-  {
-    _loop_num_editor->setText(loop_num);
-    update_loop_num();
+    if (config.mapGetString ("loop_start", &loop_start))
+      {
+        _loop_start_editor->setText (loop_start);
+        update_loop_start ();
+      }
+
+    if (config.mapGetString ("loop_finish", &loop_finish))
+      {
+        _loop_finish_editor->setText (loop_finish);
+        update_loop_finish ();
+      }
+
+    if (config.mapGetString ("loop_num", &loop_num))
+      {
+        _loop_num_editor->setText (loop_num);
+        update_loop_num ();
+      }
   }
-}
 
 // Save config
-void RmfPanel::save(rviz_common::Config config) const
-{
-  rviz_common::Panel::save(config);
-  config.mapSetValue("delivery_task_id", _delivery_task_id);
-  config.mapSetValue("delivery_robot", _delivery_robot);
-  config.mapSetValue("delivery_pickup", _delivery_pickup);
-  config.mapSetValue("delivery_dropoff", _delivery_dropoff);
+  void RmfPanel::save (rviz_common::Config config) const
+  {
+    rviz_common::Panel::save (config);
+    config.mapSetValue ("delivery_task_id", _delivery_task_id);
+    config.mapSetValue ("delivery_robot", _delivery_robot);
+    config.mapSetValue ("delivery_pickup", _delivery_pickup);
+    config.mapSetValue ("delivery_dropoff", _delivery_dropoff);
 
-  config.mapSetValue("loop_task_id", _loop_task_id);
-  config.mapSetValue("loop_robot", _loop_robot);
-  config.mapSetValue("loop_start", _loop_start);
-  config.mapSetValue("loop_finish", _loop_finish);
-  config.mapSetValue("loop_num", _loop_num);
-}
+    config.mapSetValue ("loop_task_id", _loop_task_id);
+    config.mapSetValue ("loop_robot", _loop_robot);
+    config.mapSetValue ("loop_start", _loop_start);
+    config.mapSetValue ("loop_finish", _loop_finish);
+    config.mapSetValue ("loop_num", _loop_num);
+  }
 
-} // namespace rmf_rviz_plugin
+}                               // namespace rmf_rviz_plugin
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS(rmf_rviz_plugin::RmfPanel, rviz_common::Panel)
+PLUGINLIB_EXPORT_CLASS (rmf_rviz_plugin::RmfPanel, rviz_common::Panel)

--- a/rmf_rviz_plugin/src/RmfPanel.cpp
+++ b/rmf_rviz_plugin/src/RmfPanel.cpp
@@ -13,410 +13,384 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 #include "RmfPanel.hpp"
 
-#include <QVBoxLayout>
+#include <QGridLayout>
+#include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
-#include <QGroupBox>
-#include <QGridLayout>
+#include <QVBoxLayout>
 
-namespace rmf_rviz_plugin
+namespace rmf_rviz_plugin {
+
+void RmfPanel::create_layout()
 {
+  // Layout for delivery request
+  QGridLayout *layout_delivery = new QGridLayout(this);
 
-  void RmfPanel::create_layout ()
-  {
-    // Layout for delivery request
-    QGridLayout *layout_delivery = new QGridLayout (this);
+  // Row 1
+  layout_delivery->addWidget(new QLabel("Task ID:"), 0, 0);
+  _delivery_task_id_editor = new QLineEdit;
+  _delivery_task_id_editor->setFixedWidth(150);
+  layout_delivery->addWidget(_delivery_task_id_editor, 0, 1);
 
-    // Row 1
-      layout_delivery->addWidget (new QLabel ("Task ID:"), 0, 0);
-      _delivery_task_id_editor = new QLineEdit;
-      _delivery_task_id_editor->setFixedWidth (150);
-      layout_delivery->addWidget (_delivery_task_id_editor, 0, 1);
+  layout_delivery->addWidget(new QLabel("Robot:"), 0, 2);
+  _delivery_robot_editor = new QLineEdit;
+  _delivery_robot_editor->setFixedWidth(150);
+  layout_delivery->addWidget(_delivery_robot_editor, 0, 3);
 
-      layout_delivery->addWidget (new QLabel ("Robot:"), 0, 2);
-      _delivery_robot_editor = new QLineEdit;
-      _delivery_robot_editor->setFixedWidth (150);
-      layout_delivery->addWidget (_delivery_robot_editor, 0, 3);
+  // Row 2
+  layout_delivery->addWidget(new QLabel("Pickup:"), 1, 0);
+  _delivery_pickup_editor = new QLineEdit;
+  _delivery_pickup_editor->setFixedWidth(150);
+  layout_delivery->addWidget(_delivery_pickup_editor, 1, 1);
 
-    // Row 2
-      layout_delivery->addWidget (new QLabel ("Pickup:"), 1, 0);
-      _delivery_pickup_editor = new QLineEdit;
-      _delivery_pickup_editor->setFixedWidth (150);
-      layout_delivery->addWidget (_delivery_pickup_editor, 1, 1);
+  layout_delivery->addWidget(new QLabel("Dropoff:"), 1, 2);
+  _delivery_dropoff_editor = new QLineEdit;
+  _delivery_dropoff_editor->setFixedWidth(150);
+  layout_delivery->addWidget(_delivery_dropoff_editor, 1, 3);
 
-      layout_delivery->addWidget (new QLabel ("Dropoff:"), 1, 2);
-      _delivery_dropoff_editor = new QLineEdit;
-      _delivery_dropoff_editor->setFixedWidth (150);
-      layout_delivery->addWidget (_delivery_dropoff_editor, 1, 3);
+  // Row 3
+  _delivery_button = new QPushButton(this);
+  _delivery_button->setText("Request Delivery");
+  layout_delivery->addWidget(_delivery_button, 2, 1, 1, 2);
 
-    // Row 3
-      _delivery_button = new QPushButton (this);
-      _delivery_button->setText ("Request Delivery");
-      layout_delivery->addWidget (_delivery_button, 2, 1, 1, 2);
+  // Creating box for delivery request
+  QGroupBox *delivery_box = new QGroupBox("Delivery Request");
+  delivery_box->setLayout(layout_delivery);
 
-    // Creating box for delivery request
-    QGroupBox *delivery_box = new QGroupBox ("Delivery Request");
-      delivery_box->setLayout (layout_delivery);
+  // Layout for loop request
+  // Row 1
+  QGridLayout *layout_loop = new QGridLayout(this);
+  layout_loop->addWidget(new QLabel("Task ID:"), 0, 0);
+  _loop_task_id_editor = new QLineEdit;
+  _loop_task_id_editor->setFixedWidth(150);
+  layout_loop->addWidget(_loop_task_id_editor, 0, 1);
 
-    // Layout for loop request
-    // Row 1
-    QGridLayout *layout_loop = new QGridLayout (this);
-      layout_loop->addWidget (new QLabel ("Task ID:"), 0, 0);
-      _loop_task_id_editor = new QLineEdit;
-      _loop_task_id_editor->setFixedWidth (150);
-      layout_loop->addWidget (_loop_task_id_editor, 0, 1);
+  layout_loop->addWidget(new QLabel("Robot:"), 0, 2);
+  _loop_robot_editor = new QLineEdit;
+  _loop_robot_editor->setFixedWidth(150);
+  layout_loop->addWidget(_loop_robot_editor, 0, 3);
 
-      layout_loop->addWidget (new QLabel ("Robot:"), 0, 2);
-      _loop_robot_editor = new QLineEdit;
-      _loop_robot_editor->setFixedWidth (150);
-      layout_loop->addWidget (_loop_robot_editor, 0, 3);
+  // Row 2
+  layout_loop->addWidget(new QLabel("Start:"), 1, 0);
+  _loop_start_editor = new QLineEdit;
+  _loop_start_editor->setFixedWidth(150);
+  layout_loop->addWidget(_loop_start_editor, 1, 1);
 
-    // Row 2
-      layout_loop->addWidget (new QLabel ("Start:"), 1, 0);
-      _loop_start_editor = new QLineEdit;
-      _loop_start_editor->setFixedWidth (150);
-      layout_loop->addWidget (_loop_start_editor, 1, 1);
+  layout_loop->addWidget(new QLabel("Finish:"), 1, 2);
+  _loop_finish_editor = new QLineEdit;
+  _loop_finish_editor->setFixedWidth(150);
+  layout_loop->addWidget(_loop_finish_editor, 1, 3);
 
-      layout_loop->addWidget (new QLabel ("Finish:"), 1, 2);
-      _loop_finish_editor = new QLineEdit;
-      _loop_finish_editor->setFixedWidth (150);
-      layout_loop->addWidget (_loop_finish_editor, 1, 3);
+  // Row 3
+  layout_loop->addWidget(new QLabel("Loops:"), 2, 0);
+  _loop_num_editor = new QLineEdit;
+  _loop_num_editor->setFixedWidth(100);
+  layout_loop->addWidget(_loop_num_editor, 2, 1);
 
-    // Row 3
-      layout_loop->addWidget (new QLabel ("Loops:"), 2, 0);
-      _loop_num_editor = new QLineEdit;
-      _loop_num_editor->setFixedWidth (100);
-      layout_loop->addWidget (_loop_num_editor, 2, 1);
+  // Row 4
+  _loop_button = new QPushButton(this);
+  _loop_button->setText("Request Loop");
+  layout_loop->addWidget(_loop_button, 3, 1, 1, 2);
 
-    // Row 4
-      _loop_button = new QPushButton (this);
-      _loop_button->setText ("Request Loop");
-      layout_loop->addWidget (_loop_button, 3, 1, 1, 2);
+  // Creating box for loop request
+  QGroupBox *loop_box = new QGroupBox("Loop Request");
+  loop_box->setLayout(layout_loop);
 
-    // Creating box for loop request
-    QGroupBox *loop_box = new QGroupBox ("Loop Request");
-      loop_box->setLayout (layout_loop);
+  // Combining layouts into a single vertical layout
+  QVBoxLayout *layout = new QVBoxLayout;
+  layout->addStretch();
+  layout->addWidget(loop_box);
+  layout->addWidget(delivery_box);
+  setLayout(layout);
 
-    // Combining layouts into a single vertical layout
-    QVBoxLayout *layout = new QVBoxLayout;
-      layout->addStretch ();
-      layout->addWidget (loop_box);
-      layout->addWidget (delivery_box);
-      setLayout (layout);
+  // Initialize text fields
+  _delivery_task_id_editor->setText(_delivery_task_id);
+  _delivery_pickup_editor->setText(_delivery_pickup);
+  _delivery_dropoff_editor->setText(_delivery_dropoff);
+  _delivery_robot_editor->setText(_delivery_robot);
 
-    // Initialize text fields
-      _delivery_task_id_editor->setText (_delivery_task_id);
-      _delivery_pickup_editor->setText (_delivery_pickup);
-      _delivery_dropoff_editor->setText (_delivery_dropoff);
-      _delivery_robot_editor->setText (_delivery_robot);
+  _loop_task_id_editor->setText(_loop_task_id);
+  _loop_start_editor->setText(_loop_start);
+  _loop_finish_editor->setText(_loop_finish);
+  _loop_robot_editor->setText(_loop_robot);
+  _loop_num_editor->setText(_loop_num);
 
-      _loop_task_id_editor->setText (_loop_task_id);
-      _loop_start_editor->setText (_loop_start);
-      _loop_finish_editor->setText (_loop_finish);
-      _loop_robot_editor->setText (_loop_robot);
-      _loop_num_editor->setText (_loop_num);
+  // QT signal connections
+  connect(_delivery_task_id_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_delivery_task_id()));
+  connect(_delivery_robot_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_delivery_robot()));
+  connect(_delivery_pickup_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_delivery_pickup()));
+  connect(_delivery_dropoff_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_delivery_dropoff()));
+  connect(_delivery_button, SIGNAL(clicked()), this, SLOT(request_delivery()));
 
-    // QT signal connections
-      connect (_delivery_task_id_editor,
-               SIGNAL (editingFinished ()), this,
-               SLOT (update_delivery_task_id ()));
-      connect (_delivery_robot_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_delivery_robot ()));
-      connect (_delivery_pickup_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_delivery_pickup ()));
-      connect (_delivery_dropoff_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_delivery_dropoff ()));
-      connect (_delivery_button, SIGNAL (clicked ()), this,
-               SLOT (request_delivery ()));
+  connect(_loop_task_id_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_loop_task_id()));
+  connect(_loop_robot_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_loop_robot()));
+  connect(_loop_start_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_loop_start()));
+  connect(_loop_finish_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_loop_finish()));
+  connect(_loop_num_editor, SIGNAL(editingFinished()), this,
+          SLOT(update_loop_num()));
+  connect(_loop_button, SIGNAL(clicked()), this, SLOT(request_loop()));
+}
 
-      connect (_loop_task_id_editor,
-               SIGNAL (editingFinished ()), this,
-               SLOT (update_loop_task_id ()));
-      connect (_loop_robot_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_loop_robot ()));
-      connect (_loop_start_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_loop_start ()));
-      connect (_loop_finish_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_loop_finish ()));
-      connect (_loop_num_editor, SIGNAL (editingFinished ()), this,
-               SLOT (update_loop_num ()));
-      connect (_loop_button, SIGNAL (clicked ()), this,
-               SLOT (request_loop ()));
+RmfPanel::RmfPanel(QWidget *parent)
+    : rviz_common::Panel(parent), _delivery_task_id("task#42"),
+      _delivery_robot("magni"), _delivery_pickup("pantry"),
+      _delivery_dropoff("hardware_2"), _loop_task_id("task#24"),
+      _loop_robot("magni"), _loop_start("coe"), _loop_finish("cubicle_1"),
+      _loop_num("1")
+{
+  _node = std::make_shared<rclcpp::Node>("rmf_panel_plugin");
+
+  _delivery_pub =
+      _node->create_publisher<Delivery>("/delivery_requests", rclcpp::QoS(10));
+
+  _loop_pub = _node->create_publisher<Loop>("/loop_requests", rclcpp::QoS(10));
+
+  _thread = std::thread([&]() { rclcpp::spin(_node); });
+
+  create_layout();
+  _has_loaded = true;
+}
+
+RmfPanel::~RmfPanel()
+{
+  if (_has_loaded) {
+    _thread.join();
+    rclcpp::shutdown();
   }
+}
 
-  RmfPanel::RmfPanel (QWidget * parent):rviz_common::Panel (parent),
-    _delivery_task_id ("task#42"),
-    _delivery_robot ("magni"),
-    _delivery_pickup ("pantry"),
-    _delivery_dropoff ("hardware_2"),
-    _loop_task_id ("task#24"),
-    _loop_robot ("magni"),
-    _loop_start ("coe"), _loop_finish ("cubicle_1"), _loop_num ("1")
-  {
-    _node = std::make_shared < rclcpp::Node > ("rmf_panel_plugin");
+// Delivery set functions
+void RmfPanel::set_delivery_task_id(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _delivery_task_id = value;
+  Q_EMIT configChanged();
+}
 
-    _delivery_pub =
-      _node->create_publisher < Delivery > ("/delivery_requests",
-                                            rclcpp::QoS (10));
+void RmfPanel::set_delivery_pickup(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _delivery_pickup = value;
+  Q_EMIT configChanged();
+}
 
-    _loop_pub = _node->create_publisher < Loop > ("/loop_requests",
-                                                  rclcpp::QoS (10));
+void RmfPanel::set_delivery_dropoff(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _delivery_dropoff = value;
+  Q_EMIT configChanged();
+}
 
-    _thread = std::thread ([&]()
-                           {
-                           rclcpp::spin (_node);
-                           });
-
-    create_layout ();
-    _has_loaded = true;
-  }
-
-  RmfPanel::~RmfPanel ()
-  {
-    if (_has_loaded)
-      {
-        _thread.join ();
-        rclcpp::shutdown ();
-      }
-  }
-
-// Delivery set functions 
-  void RmfPanel::set_delivery_task_id (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _delivery_task_id = value;
-    Q_EMIT configChanged ();
-  }
-
-  void RmfPanel::set_delivery_pickup (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _delivery_pickup = value;
-    Q_EMIT configChanged ();
-  }
-
-  void RmfPanel::set_delivery_dropoff (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _delivery_dropoff = value;
-    Q_EMIT configChanged ();
-  }
-
-  void RmfPanel::set_delivery_robot (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _delivery_robot = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_delivery_robot(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _delivery_robot = value;
+  Q_EMIT configChanged();
+}
 
 // Loop set functions
-  void RmfPanel::set_loop_task_id (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_task_id = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_loop_task_id(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_task_id = value;
+  Q_EMIT configChanged();
+}
 
-  void RmfPanel::set_loop_start (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_start = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_loop_start(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_start = value;
+  Q_EMIT configChanged();
+}
 
-  void RmfPanel::set_loop_finish (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_finish = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_loop_finish(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_finish = value;
+  Q_EMIT configChanged();
+}
 
-  void RmfPanel::set_loop_robot (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_robot = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_loop_robot(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_robot = value;
+  Q_EMIT configChanged();
+}
 
-  void RmfPanel::set_loop_num (const QString & value)
-  {
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_num = value;
-    Q_EMIT configChanged ();
-  }
+void RmfPanel::set_loop_num(const QString &value)
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_num = value;
+  Q_EMIT configChanged();
+}
 
-// Delivery update functions 
-  void RmfPanel::update_delivery_task_id ()
-  {
-    set_delivery_task_id (_delivery_task_id_editor->text ());
-  }
+// Delivery update functions
+void RmfPanel::update_delivery_task_id()
+{
+  set_delivery_task_id(_delivery_task_id_editor->text());
+}
 
-  void RmfPanel::update_delivery_pickup ()
-  {
-    set_delivery_pickup (_delivery_pickup_editor->text ());
-  }
+void RmfPanel::update_delivery_pickup()
+{
+  set_delivery_pickup(_delivery_pickup_editor->text());
+}
 
-  void RmfPanel::update_delivery_dropoff ()
-  {
-    set_delivery_dropoff (_delivery_dropoff_editor->text ());
-  }
+void RmfPanel::update_delivery_dropoff()
+{
+  set_delivery_dropoff(_delivery_dropoff_editor->text());
+}
 
-  void RmfPanel::update_delivery_robot ()
-  {
-    set_delivery_robot (_delivery_robot_editor->text ());
-  }
+void RmfPanel::update_delivery_robot()
+{
+  set_delivery_robot(_delivery_robot_editor->text());
+}
 
 // Loop update functions
-  void RmfPanel::update_loop_task_id ()
-  {
-    set_loop_task_id (_loop_task_id_editor->text ());
-  }
+void RmfPanel::update_loop_task_id()
+{
+  set_loop_task_id(_loop_task_id_editor->text());
+}
 
-  void RmfPanel::update_loop_start ()
-  {
-    set_loop_start (_loop_start_editor->text ());
-  }
+void RmfPanel::update_loop_start()
+{
+  set_loop_start(_loop_start_editor->text());
+}
 
-  void RmfPanel::update_loop_finish ()
-  {
-    set_loop_finish (_loop_finish_editor->text ());
-  }
+void RmfPanel::update_loop_finish()
+{
+  set_loop_finish(_loop_finish_editor->text());
+}
 
-  void RmfPanel::update_loop_robot ()
-  {
-    set_loop_robot (_loop_robot_editor->text ());
-  }
+void RmfPanel::update_loop_robot()
+{
+  set_loop_robot(_loop_robot_editor->text());
+}
 
-  void RmfPanel::update_loop_num ()
-  {
-    set_loop_num (_loop_num_editor->text ());
-  }
+void RmfPanel::update_loop_num() { set_loop_num(_loop_num_editor->text()); }
 
 // Publisher functions
-  void RmfPanel::request_delivery ()
-  {
-    Delivery delivery;
+void RmfPanel::request_delivery()
+{
+  Delivery delivery;
 
-    std::lock_guard < std::mutex > lock (_mutex);
-    _delivery_task_id =
-      _delivery_task_id == "" ? "task#42" : _delivery_task_id;
+  std::lock_guard<std::mutex> lock(_mutex);
+  _delivery_task_id = _delivery_task_id == "" ? "task#42" : _delivery_task_id;
 
-    delivery.task_id = _delivery_task_id.toStdString ();
-    delivery.pickup_place_name = _delivery_pickup.toStdString ();
-    delivery.dropoff_place_name = _delivery_dropoff.toStdString ();
+  delivery.task_id = _delivery_task_id.toStdString();
+  delivery.pickup_place_name = _delivery_pickup.toStdString();
+  delivery.dropoff_place_name = _delivery_dropoff.toStdString();
 
-    _delivery_pub->publish (delivery);
-    RCLCPP_INFO (_node->get_logger (), "Published delivery request");
-  }
+  _delivery_pub->publish(delivery);
+  RCLCPP_INFO(_node->get_logger(), "Published delivery request");
+}
 
-  void RmfPanel::request_loop ()
-  {
-    Loop loop;
+void RmfPanel::request_loop()
+{
+  Loop loop;
 
-    std::lock_guard < std::mutex > lock (_mutex);
-    _loop_task_id = _loop_task_id == "" ? "task#24" : _loop_task_id;
+  std::lock_guard<std::mutex> lock(_mutex);
+  _loop_task_id = _loop_task_id == "" ? "task#24" : _loop_task_id;
 
-    loop.task_id = _loop_task_id.toStdString ();
-    loop.robot_type = _loop_robot.toStdString ();
-    loop.num_loops = _loop_num.toUInt ();
-    loop.start_name = _loop_start.toStdString ();
-    loop.finish_name = _loop_finish.toStdString ();
+  loop.task_id = _loop_task_id.toStdString();
+  loop.robot_type = _loop_robot.toStdString();
+  loop.num_loops = _loop_num.toUInt();
+  loop.start_name = _loop_start.toStdString();
+  loop.finish_name = _loop_finish.toStdString();
 
-    _loop_pub->publish (loop);
-    RCLCPP_INFO (_node->get_logger (), "Published loop request");
-  }
+  _loop_pub->publish(loop);
+  RCLCPP_INFO(_node->get_logger(), "Published loop request");
+}
 
 // Load config
-  void RmfPanel::load (const rviz_common::Config & config)
-  {
-    rviz_common::Panel::load (config);
-    QString delivery_task_id;
-    QString delivery_robot;
-    QString delivery_pickup;
-    QString delivery_dropoff;
+void RmfPanel::load(const rviz_common::Config &config)
+{
+  rviz_common::Panel::load(config);
+  QString delivery_task_id;
+  QString delivery_robot;
+  QString delivery_pickup;
+  QString delivery_dropoff;
 
-    QString loop_task_id;
-    QString loop_robot;
-    QString loop_start;
-    QString loop_finish;
-    QString loop_num;
+  QString loop_task_id;
+  QString loop_robot;
+  QString loop_start;
+  QString loop_finish;
+  QString loop_num;
 
-    if (config.mapGetString ("delivery_task_id", &delivery_task_id))
-      {
-        _delivery_task_id_editor->setText (delivery_task_id);
-        update_delivery_task_id ();
-      }
-
-    if (config.mapGetString ("delivery_robot", &delivery_robot))
-      {
-        _delivery_robot_editor->setText (delivery_robot);
-        update_delivery_robot ();
-      }
-
-    if (config.mapGetString ("delivery_pickup", &delivery_pickup))
-      {
-        _delivery_pickup_editor->setText (delivery_pickup);
-        update_delivery_pickup ();
-      }
-
-    if (config.mapGetString ("delivery_dropoff", &delivery_dropoff))
-      {
-        _delivery_dropoff_editor->setText (delivery_dropoff);
-        update_delivery_dropoff ();
-      }
-
-    if (config.mapGetString ("loop_task_id", &loop_task_id))
-      {
-        _loop_task_id_editor->setText (loop_task_id);
-        update_loop_task_id ();
-      }
-
-    if (config.mapGetString ("loop_robot", &loop_robot))
-      {
-        _loop_robot_editor->setText (loop_robot);
-        update_loop_robot ();
-      }
-
-    if (config.mapGetString ("loop_start", &loop_start))
-      {
-        _loop_start_editor->setText (loop_start);
-        update_loop_start ();
-      }
-
-    if (config.mapGetString ("loop_finish", &loop_finish))
-      {
-        _loop_finish_editor->setText (loop_finish);
-        update_loop_finish ();
-      }
-
-    if (config.mapGetString ("loop_num", &loop_num))
-      {
-        _loop_num_editor->setText (loop_num);
-        update_loop_num ();
-      }
+  if (config.mapGetString("delivery_task_id", &delivery_task_id)) {
+    _delivery_task_id_editor->setText(delivery_task_id);
+    update_delivery_task_id();
   }
+
+  if (config.mapGetString("delivery_robot", &delivery_robot)) {
+    _delivery_robot_editor->setText(delivery_robot);
+    update_delivery_robot();
+  }
+
+  if (config.mapGetString("delivery_pickup", &delivery_pickup)) {
+    _delivery_pickup_editor->setText(delivery_pickup);
+    update_delivery_pickup();
+  }
+
+  if (config.mapGetString("delivery_dropoff", &delivery_dropoff)) {
+    _delivery_dropoff_editor->setText(delivery_dropoff);
+    update_delivery_dropoff();
+  }
+
+  if (config.mapGetString("loop_task_id", &loop_task_id)) {
+    _loop_task_id_editor->setText(loop_task_id);
+    update_loop_task_id();
+  }
+
+  if (config.mapGetString("loop_robot", &loop_robot)) {
+    _loop_robot_editor->setText(loop_robot);
+    update_loop_robot();
+  }
+
+  if (config.mapGetString("loop_start", &loop_start)) {
+    _loop_start_editor->setText(loop_start);
+    update_loop_start();
+  }
+
+  if (config.mapGetString("loop_finish", &loop_finish)) {
+    _loop_finish_editor->setText(loop_finish);
+    update_loop_finish();
+  }
+
+  if (config.mapGetString("loop_num", &loop_num)) {
+    _loop_num_editor->setText(loop_num);
+    update_loop_num();
+  }
+}
 
 // Save config
-  void RmfPanel::save (rviz_common::Config config) const
-  {
-    rviz_common::Panel::save (config);
-    config.mapSetValue ("delivery_task_id", _delivery_task_id);
-    config.mapSetValue ("delivery_robot", _delivery_robot);
-    config.mapSetValue ("delivery_pickup", _delivery_pickup);
-    config.mapSetValue ("delivery_dropoff", _delivery_dropoff);
+void RmfPanel::save(rviz_common::Config config) const
+{
+  rviz_common::Panel::save(config);
+  config.mapSetValue("delivery_task_id", _delivery_task_id);
+  config.mapSetValue("delivery_robot", _delivery_robot);
+  config.mapSetValue("delivery_pickup", _delivery_pickup);
+  config.mapSetValue("delivery_dropoff", _delivery_dropoff);
 
-    config.mapSetValue ("loop_task_id", _loop_task_id);
-    config.mapSetValue ("loop_robot", _loop_robot);
-    config.mapSetValue ("loop_start", _loop_start);
-    config.mapSetValue ("loop_finish", _loop_finish);
-    config.mapSetValue ("loop_num", _loop_num);
-  }
+  config.mapSetValue("loop_task_id", _loop_task_id);
+  config.mapSetValue("loop_robot", _loop_robot);
+  config.mapSetValue("loop_start", _loop_start);
+  config.mapSetValue("loop_finish", _loop_finish);
+  config.mapSetValue("loop_num", _loop_num);
+}
 
-}                               // namespace rmf_rviz_plugin
+} // namespace rmf_rviz_plugin
 
 #include <pluginlib/class_list_macros.hpp>
-PLUGINLIB_EXPORT_CLASS (rmf_rviz_plugin::RmfPanel, rviz_common::Panel)
+PLUGINLIB_EXPORT_CLASS(rmf_rviz_plugin::RmfPanel, rviz_common::Panel)

--- a/rmf_rviz_plugin/src/RmfPanel.hpp
+++ b/rmf_rviz_plugin/src/RmfPanel.hpp
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 #ifndef RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP
 #define RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP
 
-#include <rviz_common/panel.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rviz_common/panel.hpp>
 
 #include <rmf_task_msgs/msg/delivery.hpp>
 #include <rmf_task_msgs/msg/loop.hpp>
@@ -28,88 +28,85 @@
 #include <QPushButton>
 
 #include <memory>
-#include <thread>
 #include <mutex>
+#include <thread>
 
-namespace rmf_rviz_plugin
-{
+namespace rmf_rviz_plugin {
 
-  using Delivery = rmf_task_msgs::msg::Delivery;
-  using Loop = rmf_task_msgs::msg::Loop;
+using Delivery = rmf_task_msgs::msg::Delivery;
+using Loop = rmf_task_msgs::msg::Loop;
 
-  class RmfPanel:public rviz_common::Panel
-  {
-  Q_OBJECT public:
-    RmfPanel (QWidget * parent = 0);
-    ~RmfPanel ();
+class RmfPanel : public rviz_common::Panel {
+  Q_OBJECT public : RmfPanel(QWidget *parent = 0);
+  ~RmfPanel();
 
-    virtual void load (const rviz_common::Config & config);
-    virtual void save (rviz_common::Config config) const;
+  virtual void load(const rviz_common::Config &config);
+  virtual void save(rviz_common::Config config) const;
 
-    public Q_SLOTS:void set_delivery_task_id (const QString & value);
-    void set_delivery_pickup (const QString & value);
-    void set_delivery_dropoff (const QString & value);
-    void set_delivery_robot (const QString & value);
+public Q_SLOTS:
+  void set_delivery_task_id(const QString &value);
+  void set_delivery_pickup(const QString &value);
+  void set_delivery_dropoff(const QString &value);
+  void set_delivery_robot(const QString &value);
 
-    void set_loop_task_id (const QString & value);
-    void set_loop_start (const QString & value);
-    void set_loop_finish (const QString & value);
-    void set_loop_robot (const QString & value);
-    void set_loop_num (const QString & value);
+  void set_loop_task_id(const QString &value);
+  void set_loop_start(const QString &value);
+  void set_loop_finish(const QString &value);
+  void set_loop_robot(const QString &value);
+  void set_loop_num(const QString &value);
 
-    protected Q_SLOTS:void update_delivery_task_id ();
-    void update_delivery_pickup ();
-    void update_delivery_dropoff ();
-    void update_delivery_robot ();
-    void request_delivery ();
+protected Q_SLOTS:
+  void update_delivery_task_id();
+  void update_delivery_pickup();
+  void update_delivery_dropoff();
+  void update_delivery_robot();
+  void request_delivery();
 
-    void update_loop_task_id ();
-    void update_loop_start ();
-    void update_loop_finish ();
-    void update_loop_robot ();
-    void update_loop_num ();
-    void request_loop ();
+  void update_loop_task_id();
+  void update_loop_start();
+  void update_loop_finish();
+  void update_loop_robot();
+  void update_loop_num();
+  void request_loop();
 
-  protected:
+protected:
+  void create_layout();
 
-    void create_layout ();
+  QLineEdit *_delivery_task_id_editor;
+  QLineEdit *_delivery_pickup_editor;
+  QLineEdit *_delivery_dropoff_editor;
+  QLineEdit *_delivery_robot_editor;
 
-    QLineEdit *_delivery_task_id_editor;
-    QLineEdit *_delivery_pickup_editor;
-    QLineEdit *_delivery_dropoff_editor;
-    QLineEdit *_delivery_robot_editor;
+  QLineEdit *_loop_task_id_editor;
+  QLineEdit *_loop_start_editor;
+  QLineEdit *_loop_finish_editor;
+  QLineEdit *_loop_robot_editor;
+  QLineEdit *_loop_num_editor;
 
-    QLineEdit *_loop_task_id_editor;
-    QLineEdit *_loop_start_editor;
-    QLineEdit *_loop_finish_editor;
-    QLineEdit *_loop_robot_editor;
-    QLineEdit *_loop_num_editor;
+  QPushButton *_delivery_button;
+  QPushButton *_loop_button;
 
-    QPushButton *_delivery_button;
-    QPushButton *_loop_button;
+  QString _delivery_task_id;
+  QString _delivery_robot;
+  QString _delivery_pickup;
+  QString _delivery_dropoff;
 
-    QString _delivery_task_id;
-    QString _delivery_robot;
-    QString _delivery_pickup;
-    QString _delivery_dropoff;
+  QString _loop_task_id;
+  QString _loop_robot;
+  QString _loop_start;
+  QString _loop_finish;
+  QString _loop_num;
 
-    QString _loop_task_id;
-    QString _loop_robot;
-    QString _loop_start;
-    QString _loop_finish;
-    QString _loop_num;
+  rclcpp::Node::SharedPtr _node;
+  rclcpp::Publisher<Delivery>::SharedPtr _delivery_pub;
+  rclcpp::Publisher<Loop>::SharedPtr _loop_pub;
 
-      rclcpp::Node::SharedPtr _node;
-      rclcpp::Publisher < Delivery >::SharedPtr _delivery_pub;
-      rclcpp::Publisher < Loop >::SharedPtr _loop_pub;
+  bool _has_loaded = false;
 
-    bool _has_loaded = false;
+  std::thread _thread;
+  std::mutex _mutex;
+};
 
-      std::thread _thread;
-      std::mutex _mutex;
+} // namespace rmf_rviz_plugin
 
-  };
-
-}                               // namespace rmf_rviz_plugin
-
-#endif                          // RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP
+#endif // RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP

--- a/rmf_rviz_plugin/src/RmfPanel.hpp
+++ b/rmf_rviz_plugin/src/RmfPanel.hpp
@@ -31,87 +31,85 @@
 #include <thread>
 #include <mutex>
 
-namespace rmf_rviz_plugin {
-
-using Delivery = rmf_task_msgs::msg::Delivery;
-using Loop = rmf_task_msgs::msg::Loop;
-
-class RmfPanel : public rviz_common::Panel
+namespace rmf_rviz_plugin
 {
-Q_OBJECT
-public:
-  RmfPanel(QWidget* parent = 0);
-  ~RmfPanel();
 
-  virtual void load(const rviz_common::Config& config);
-  virtual void save(rviz_common::Config config) const;
+  using Delivery = rmf_task_msgs::msg::Delivery;
+  using Loop = rmf_task_msgs::msg::Loop;
 
-public Q_SLOTS:
-  void set_delivery_task_id(const QString& value);
-  void set_delivery_pickup(const QString& value);
-  void set_delivery_dropoff(const QString& value);
-  void set_delivery_robot(const QString& value);
+  class RmfPanel:public rviz_common::Panel
+  {
+  Q_OBJECT public:
+    RmfPanel (QWidget * parent = 0);
+    ~RmfPanel ();
 
-  void set_loop_task_id(const QString& value);
-  void set_loop_start(const QString& value);
-  void set_loop_finish(const QString& value);
-  void set_loop_robot(const QString& value);
-  void set_loop_num(const QString& value);
+    virtual void load (const rviz_common::Config & config);
+    virtual void save (rviz_common::Config config) const;
 
-protected Q_SLOTS:
-  void update_delivery_task_id();
-  void update_delivery_pickup();
-  void update_delivery_dropoff();
-  void update_delivery_robot();
-  void request_delivery();
+    public Q_SLOTS:void set_delivery_task_id (const QString & value);
+    void set_delivery_pickup (const QString & value);
+    void set_delivery_dropoff (const QString & value);
+    void set_delivery_robot (const QString & value);
 
-  void update_loop_task_id();
-  void update_loop_start();
-  void update_loop_finish();
-  void update_loop_robot();
-  void update_loop_num();
-  void request_loop();
+    void set_loop_task_id (const QString & value);
+    void set_loop_start (const QString & value);
+    void set_loop_finish (const QString & value);
+    void set_loop_robot (const QString & value);
+    void set_loop_num (const QString & value);
 
-protected:
-  
-  void create_layout();
+    protected Q_SLOTS:void update_delivery_task_id ();
+    void update_delivery_pickup ();
+    void update_delivery_dropoff ();
+    void update_delivery_robot ();
+    void request_delivery ();
 
-  QLineEdit* _delivery_task_id_editor;
-  QLineEdit* _delivery_pickup_editor;
-  QLineEdit* _delivery_dropoff_editor;
-  QLineEdit* _delivery_robot_editor;
+    void update_loop_task_id ();
+    void update_loop_start ();
+    void update_loop_finish ();
+    void update_loop_robot ();
+    void update_loop_num ();
+    void request_loop ();
 
-  QLineEdit* _loop_task_id_editor;
-  QLineEdit* _loop_start_editor;
-  QLineEdit* _loop_finish_editor;
-  QLineEdit* _loop_robot_editor;
-  QLineEdit* _loop_num_editor;
+  protected:
 
-  QPushButton* _delivery_button;
-  QPushButton* _loop_button;
+    void create_layout ();
 
-  QString _delivery_task_id;
-  QString _delivery_robot;
-  QString _delivery_pickup;
-  QString _delivery_dropoff;
+    QLineEdit *_delivery_task_id_editor;
+    QLineEdit *_delivery_pickup_editor;
+    QLineEdit *_delivery_dropoff_editor;
+    QLineEdit *_delivery_robot_editor;
 
-  QString _loop_task_id;
-  QString _loop_robot;
-  QString _loop_start;
-  QString _loop_finish;
-  QString _loop_num;
+    QLineEdit *_loop_task_id_editor;
+    QLineEdit *_loop_start_editor;
+    QLineEdit *_loop_finish_editor;
+    QLineEdit *_loop_robot_editor;
+    QLineEdit *_loop_num_editor;
 
-  rclcpp::Node::SharedPtr _node;
-  rclcpp::Publisher<Delivery>::SharedPtr _delivery_pub;
-  rclcpp::Publisher<Loop>::SharedPtr _loop_pub;
+    QPushButton *_delivery_button;
+    QPushButton *_loop_button;
 
-  bool _has_loaded = false;
-  
-  std::thread _thread;
-  std::mutex _mutex;
+    QString _delivery_task_id;
+    QString _delivery_robot;
+    QString _delivery_pickup;
+    QString _delivery_dropoff;
 
-};
+    QString _loop_task_id;
+    QString _loop_robot;
+    QString _loop_start;
+    QString _loop_finish;
+    QString _loop_num;
 
-} // namespace rmf_rviz_plugin
+      rclcpp::Node::SharedPtr _node;
+      rclcpp::Publisher < Delivery >::SharedPtr _delivery_pub;
+      rclcpp::Publisher < Loop >::SharedPtr _loop_pub;
 
-#endif // RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP
+    bool _has_loaded = false;
+
+      std::thread _thread;
+      std::mutex _mutex;
+
+  };
+
+}                               // namespace rmf_rviz_plugin
+
+#endif                          // RMF_RVIZ__PLUGIN__SRC__CONTROL_HPP


### PR DESCRIPTION
This pull request proposes to implement a quick change to `teleport.cpp` that will automatically reset the dispensed payload to its original location after 3.0s. This allows for subsequent deliveries from the same dispensing location to be more "visually correct".

You might need https://github.com/osrf/rmf_core/pull/88 to handle multiple deliveries.