### PR TITLE
Minor enhancement to readonly plugin

### DIFF
--- a/demos/launch/include/airport_terminal/airport_terminal_caddy.launch.xml
+++ b/demos/launch/include/airport_terminal/airport_terminal_caddy.launch.xml
@@ -2,9 +2,6 @@
 
 <launch>
 
-  <!-- Basic airport_terminal launch -->
-  <include file="$(find-pkg-share demos)/airport_terminal.launch.xml" />
-
   <!-- Caddy spawner, fleet adapter and robot state aggregator needed for Caddy readonly_plugin -->
   <group>
     <let name="fleet_name" value="caddy"/>

--- a/rmf_demo_assets/models/Caddy/model.sdf
+++ b/rmf_demo_assets/models/Caddy/model.sdf
@@ -10,14 +10,20 @@
   <model name="caddy">
 
     <plugin name="readonly" filename="libreadonly.so">
+      <!-- Map name where the robot is spawned -->
       <level_name>L1</level_name>
+      <!-- Index of navigation graph for the robot as stored in BuildingMap msg -->
       <graph_index>1</graph_index>
+      <!-- Name of waypoint where caddy is spawned in the map -->
       <spawn_waypoint>caddy</spawn_waypoint>
+      <!-- Number of waypoints to include in predicted path -->
       <look_ahead>3</look_ahead>
-      <nominal_drive_speed>0.7</nominal_drive_speed>
-      <nominal_drive_acceleration>0.5</nominal_drive_acceleration>
-      <nominal_turn_speed>0.6</nominal_turn_speed>
-      <nominal_turn_acceleration>1.5</nominal_turn_acceleration>
+      <!-- Update rate (hz) at which robot_state is published -->
+      <update_rate>15</update_rate> 
+      <!-- Waypoint threshold (m). Radius around the waypoint to determine if caddy is at that waypoint   -->
+      <waypoint_threshold>2.0</waypoint_threshold>
+      <!-- If true, predicted path will merge robot with nearest lane -->
+      <merge_lane>true</merge_lane>
     </plugin>
 
     <plugin name="caddy_diff_controller" filename="libgazebo_ros_diff_drive.so">

--- a/rmf_demo_assets/models/Caddy/model.sdf
+++ b/rmf_demo_assets/models/Caddy/model.sdf
@@ -24,6 +24,8 @@
       <waypoint_threshold>2.0</waypoint_threshold>
       <!-- If true, predicted path will merge robot with nearest lane -->
       <merge_lane>true</merge_lane>
+      <!-- Normal distance of robot from its lane, greater than which its path will merge with the lane -->
+      <lane_threshold>0.2</lane_threshold>
     </plugin>
 
     <plugin name="caddy_diff_controller" filename="libgazebo_ros_diff_drive.so">

--- a/rmf_gazebo_plugins/src/readonly.cpp
+++ b/rmf_gazebo_plugins/src/readonly.cpp
@@ -438,18 +438,19 @@ ReadonlyPlugin::Path ReadonlyPlugin::compute_path(const ignition::math::Pose3d& 
     auto lane_vector = ignition::math::Vector3d{
       _graph.vertices[target].x - _graph.vertices[_start_wp].x,
       _graph.vertices[target].y - _graph.vertices[_start_wp].y,
-      0}.Normalize();
+      0};
 
     // Vector from target to robot
     auto disp_vector = ignition::math::Vector3d{
       _graph.vertices[target].x - pose.Pos().X(),
       _graph.vertices[target].y - pose.Pos().Y(),
-      0}.Normalize();
+      0};
 
     // Angle between lane_vector and disp_vector
     double theta = std::atan2(lane_vector.Y(), lane_vector.X()) -
       std::atan2(disp_vector.Y(), disp_vector.X());
 
+    double lane_error = std::sqrt()
     // TODO use tranformation matrices
     // Rotate position of robot about target by theta
     auto robot_x = pose.Pos().X() - _graph.vertices[target].x;

--- a/rmf_gazebo_plugins/src/readonly.cpp
+++ b/rmf_gazebo_plugins/src/readonly.cpp
@@ -437,8 +437,8 @@ ReadonlyPlugin::Path ReadonlyPlugin::compute_path(const ignition::math::Pose3d& 
     double lane_error = std::pow(disp_vector.Length(), 2) -
         std::pow(disp_vector.Dot(lane_vector.Normalize()), 2);
     
-    RCLCPP_ERROR(logger(), "Disp: [%f] lane: [%f], Lane error: [%f]",
-      disp_vector.Length(), disp_vector.Dot(lane_vector.Normalize()),lane_error);
+    // RCLCPP_ERROR(logger(), "Disp: [%f] lane: [%f], Lane error: [%f]",
+    //   disp_vector.Length(), disp_vector.Dot(lane_vector.Normalize()),lane_error);
 
     if (lane_error > _lane_threshold)
     {


### PR DESCRIPTION
When the steerable robot is not exactly on its lane (difficult to achieve with human control), the first leg of its predicted does not fully overlap with the underlying lane [see below]. This could at times lead to conflicts not being detected especially if the error is large. 

![image](https://user-images.githubusercontent.com/13482049/78007737-45eed480-7371-11ea-9d38-90cbc3cb71bb.png)

When plugin parameter `merge_lane` is set `true`, the path of the robot is prepended a point representing the projection of the robot onto the closest lane. The ensures that the rest of the path completely overlaps with the underlying lane. A `lane_threshold` parameter which represents the perpendicular distance of the robot from the lane is used to control the sensitivity of this behavior.

![image](https://user-images.githubusercontent.com/13482049/78008794-ae8a8100-7372-11ea-9336-f0830847b81a.png)

Also moved `airport_terminal_caddy.lanch.xml` into `include/airport_terminal/`.