### PR TITLE
added launch xml to exec depend

### DIFF
--- a/demos/package.xml
+++ b/demos/package.xml
@@ -25,6 +25,7 @@
 
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
+  <exec_depend>launch_xml</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
* adding `launch_xml` so `rosdep` will help install it, unsure when it will be patched upstream anyway

* solves https://github.com/osrf/rmf_demos/issues/55, https://github.com/osrf/rmf_demos/issues/49