### PR TITLE
fix gazebo_ros_pkgs meta package as dependency

### DIFF
--- a/demos/package.xml
+++ b/demos/package.xml
@@ -18,7 +18,7 @@
 
   <exec_depend>visualizer</exec_depend>
 
-  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_ros_pkgs</exec_depend>
   <exec_depend>rmf_demo_assets</exec_depend>
   <exec_depend>rmf_gazebo_plugins</exec_depend>
   <exec_depend>rmf_demo_tasks</exec_depend>


### PR DESCRIPTION
* fix to target the meta package `gazebo_ros_pkgs`, https://github.com/ros-simulation/gazebo_ros_pkgs/blob/eloquent/gazebo_ros_pkgs/package.xml

My bad for targetting the wrong package name :sweat_smile: 

fixes https://github.com/osrf/rmf_demos/issues/57