### PR TITLE
Use AxisAlignedBox instead of Box for bounding boxes

### DIFF
--- a/rmf_gazebo_plugins/src/TeleportDispenser.cpp
+++ b/rmf_gazebo_plugins/src/TeleportDispenser.cpp
@@ -61,7 +61,7 @@ private:
   gazebo::physics::ModelPtr _item_model;
   gazebo::physics::WorldPtr _world;
 
-  ignition::math::Box _dispenser_vicinity_box;
+  ignition::math::AxisAlignedBox _dispenser_vicinity_box;
 
   gazebo_ros::Node::SharedPtr _node;
   rclcpp::Subscription<FleetState>::SharedPtr _fleet_state_sub;
@@ -238,7 +238,7 @@ public:
     corner_2.X(dispenser_pos.X() + 0.05);
     corner_2.Y(dispenser_pos.Y() + 0.05);
     corner_2.Z(dispenser_pos.Z() + 0.05);
-    _dispenser_vicinity_box = ignition::math::Box(corner_1, corner_2);
+    _dispenser_vicinity_box = ignition::math::AxisAlignedBox(corner_1, corner_2);
 
     auto model_list = _world->Models();
     double nearest_dist = 1.0;

--- a/rmf_gazebo_plugins/src/TeleportIngestor.cpp
+++ b/rmf_gazebo_plugins/src/TeleportIngestor.cpp
@@ -116,12 +116,12 @@ private:
     if (!robot_model)
       return false;
 
-    const ignition::math::Box robot_collision_bb = robot_model->BoundingBox();
+    const auto robot_collision_bb = robot_model->BoundingBox();
     ignition::math::Vector3d max_corner = robot_collision_bb.Max();
 
     // create a new bounding box extended slightly in the Z direction
     max_corner.Z(max_corner.Z() + 0.1);
-    const ignition::math::Box vicinity_box(
+    const ignition::math::AxisAlignedBox vicinity_box(
       robot_collision_bb.Min(), max_corner);
 
     // There might not be a better way to loop through all the models, as we


### PR DESCRIPTION
The `ignition::math` API version 6.4 changes the `Box` class to [`AxisAlignedBox` class](https://ignitionrobotics.org/api/math/6.4/classignition_1_1math_1_1AxisAlignedBox.html), and adds a [new `Box` class for generic boxes](https://ignitionrobotics.org/api/math/6.4/classignition_1_1math_1_1Box.html). This PR changes the use of `Box` (from `ignition::math` version 4) to `AxisAlignedBox`, since all uses are bounding boxes.