### PR TITLE
Plugin library path should be relative

### DIFF
--- a/rmf_rviz_plugin/plugin_description.xml
+++ b/rmf_rviz_plugin/plugin_description.xml
@@ -1,4 +1,4 @@
-<library path="/librmf_rviz_plugin">
+<library path="rmf_rviz_plugin">
   <class name="RMF Panel"
          type="rmf_rviz_plugin::RmfPanel"
          base_class_type="rviz_common::Panel">


### PR DESCRIPTION
Plugin library paths [need to be relative](http://wiki.ros.org/pluginlib/Tutorials/Writing%20and%20Using%20a%20Simple%20Plugin#The_Plugin_XML_File) for them to be found properly.

I don't know why this wasn't a problem on Eloquent. It might be related to [this change](https://github.com/ros/pluginlib/pull/186) to how library names are retrieved?

This needs testing on Eloquent.