### PR TITLE
Fix build problems

### DIFF
--- a/rmf_demo_maps/CMakeLists.txt
+++ b/rmf_demo_maps/CMakeLists.txt
@@ -16,10 +16,8 @@ file(GLOB_RECURSE traffic_editor_paths "maps/*.building.yaml")
 foreach(path ${traffic_editor_paths})
 
   # Get the output world name
-  string(REPLACE "." ";" list1 ${path})
-  list(GET list1 0 name)
-  string(REPLACE "/" ";" list2 ${name})
-  list(GET list2 -1 world_name)
+  string(REGEX REPLACE "\\.[^.]*\.[^.]*$" "" no_extension_path ${path})
+  string(REGEX MATCH "[^\/]+$" world_name  ${no_extension_path})
 
   set(map_path ${path})
   set(output_world_name ${world_name})

--- a/rmf_demo_maps/package.xml
+++ b/rmf_demo_maps/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>building_map_tools</buildtool_depend>
+  <buildtool_depend>ros2run</buildtool_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Build used to fail if there was dots in the path to rmf_demos