### PR TITLE
Remove redundant moves to enable RVO

### DIFF
--- a/rmf_rviz_plugin/src/ParseActionPlan.cpp
+++ b/rmf_rviz_plugin/src/ParseActionPlan.cpp
@@ -245,7 +245,7 @@ rmf_utils::optional<ActionPlan> parse_yaml_config(const std::string& path_name)
 
   std::cout << "Action Plan complete." << std::endl;
 
-  return std::move(_action_plan);
+  return _action_plan;
 
 }
 } // namespace rmf_rviz_plugin

--- a/rmf_rviz_plugin/src/ParseGraph.cpp
+++ b/rmf_rviz_plugin/src/ParseGraph.cpp
@@ -228,7 +228,7 @@ rmf_utils::optional<GraphInfo> parse_graph(
     std::cout << "\n -- [" << key.first << "]";
   std::cout << std::endl;
 
-  return std::move(info);
+  return info;
 }
 
 } // namespace rmf_rviz_plugin


### PR DESCRIPTION
This PR removes a couple of `std::move` usages that are redundant and preventing RVO, because they are turning a local variable into an rvalue reference.