### PR TITLE
Modify TeleportIngestorPlugin to use rmf_ingestor_msgs

### DIFF
--- a/demos/launch/include/airport_terminal/airport_terminal.rviz
+++ b/demos/launch/include/airport_terminal/airport_terminal.rviz
@@ -34,7 +34,7 @@ Panels:
     Topic: /rviz_node/param
   - Class: RMF Panel
     Name: RMF Panel
-    dropoff_dispenser: mopcart_collector
+    dropoff_ingestor: mopcart_collector
     pickup_dispenser: mopcart_dispenser
 Visualization Manager:
   Class: ""

--- a/demos/launch/include/office/office.rviz
+++ b/demos/launch/include/office/office.rviz
@@ -23,7 +23,7 @@ Panels:
     Splitter Ratio: 0.5
   - Class: RMF Panel
     Name: RMF Panel
-    dropoff_dispenser: coke_ingestor
+    dropoff_ingestor: coke_ingestor
     pickup_dispenser: coke_dispenser
   - Class: rviz2_plugin/SchedulePanel
     Finish: 600

--- a/rmf_demo_tasks/rmf_demo_tasks/request_delivery.py
+++ b/rmf_demo_tasks/rmf_demo_tasks/request_delivery.py
@@ -24,8 +24,8 @@ def main(argv=sys.argv):
                         '--dropoff',
                         default='hardware_2', help='Finish waypoint')
     parser.add_argument('-dd',
-                        '--dropoff_dispenser',
-                        default='coke_ingestor', help='Dropoff dispenser name')
+                        '--dropoff_ingestor',
+                        default='coke_ingestor', help='Dropoff ingestor name')
     parser.add_argument('-i',
                         '--task-id', help='Task ID', default='', type=str)
     parser.add_argument('-r',
@@ -47,7 +47,7 @@ def main(argv=sys.argv):
     request.pickup_place_name = args.pickup
     request.dropoff_place_name = args.dropoff
     request.pickup_dispenser = args.pickup_dispenser
-    request.dropoff_dispenser = args.dropoff_dispenser
+    request.dropoff_ingestor = args.dropoff_ingestor
 
     for _ in range(5):
         publisher.publish(request)

--- a/rmf_gazebo_plugins/CMakeLists.txt
+++ b/rmf_gazebo_plugins/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(gazebo_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(rmf_fleet_msgs REQUIRED)
 find_package(rmf_dispenser_msgs REQUIRED)
+find_package(rmf_ingestor_msgs REQUIRED)
 find_package(building_map_msgs REQUIRED)
 
 include(GNUInstallDirs)
@@ -67,7 +68,7 @@ ament_target_dependencies(teleport_ingestor
   rclcpp
   gazebo_ros
   rmf_fleet_msgs
-  rmf_dispenser_msgs
+  rmf_ingestor_msgs
 )
 
 target_include_directories(teleport_ingestor

--- a/rmf_gazebo_plugins/package.xml
+++ b/rmf_gazebo_plugins/package.xml
@@ -21,6 +21,7 @@
   
   <depend>rmf_fleet_msgs</depend>
   <depend>rmf_dispenser_msgs</depend>
+  <depend>rmf_ingestor_msgs</depend>
   <depend>building_map_msgs</depend>
 
   <export>

--- a/rmf_gazebo_plugins/src/TeleportIngestor.cpp
+++ b/rmf_gazebo_plugins/src/TeleportIngestor.cpp
@@ -33,9 +33,10 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <rmf_fleet_msgs/msg/fleet_state.hpp>
-#include <rmf_dispenser_msgs/msg/dispenser_state.hpp>
-#include <rmf_dispenser_msgs/msg/dispenser_result.hpp>
-#include <rmf_dispenser_msgs/msg/dispenser_request.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_state.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_result.hpp>
+#include <rmf_ingestor_msgs/msg/ingestor_request.hpp>
+
 
 namespace rmf_gazebo_plugins {
 
@@ -45,9 +46,9 @@ class TeleportIngestorPlugin : public gazebo::ModelPlugin
 public:
 
   using FleetState = rmf_fleet_msgs::msg::FleetState;
-  using DispenserState = rmf_dispenser_msgs::msg::DispenserState;
-  using DispenserRequest = rmf_dispenser_msgs::msg::DispenserRequest;
-  using DispenserResult = rmf_dispenser_msgs::msg::DispenserResult;
+  using IngestorState = rmf_ingestor_msgs::msg::IngestorState;
+  using IngestorRequest = rmf_ingestor_msgs::msg::IngestorRequest;
+  using IngestorResult = rmf_ingestor_msgs::msg::IngestorResult;
   using Pose3d = ignition::math::Pose3d;
 
 private:
@@ -63,9 +64,9 @@ private:
 
   gazebo_ros::Node::SharedPtr _node;
   rclcpp::Subscription<FleetState>::SharedPtr _fleet_state_sub;
-  rclcpp::Publisher<DispenserState>::SharedPtr _state_pub;
-  rclcpp::Subscription<DispenserRequest>::SharedPtr _request_sub;
-  rclcpp::Publisher<DispenserResult>::SharedPtr _result_pub;
+  rclcpp::Publisher<IngestorState>::SharedPtr _state_pub;
+  rclcpp::Subscription<IngestorRequest>::SharedPtr _request_sub;
+  rclcpp::Publisher<IngestorResult>::SharedPtr _result_pub;
 
   std::unordered_map<std::string, ignition::math::Pose3d>
   _non_static_models_init_poses;
@@ -74,7 +75,7 @@ private:
 
   std::unordered_map<std::string, bool> _past_request_guids;
 
-  DispenserState _current_state;
+  IngestorState _current_state;
 
   rclcpp::Time simulation_now() const
   {
@@ -211,7 +212,7 @@ private:
   void send_ingestor_response(
     const std::string& request_guid, uint8_t status) const
   {
-    DispenserResult response;
+    IngestorResult response;
     response.time = simulation_now();
     response.request_guid = request_guid;
     response.source_guid = _guid;
@@ -219,7 +220,7 @@ private:
     _result_pub->publish(response);
   }
 
-  void dispenser_request_cb(DispenserRequest::UniquePtr msg)
+  void ingestor_request_cb(IngestorRequest::UniquePtr msg)
   {
     // TODO: the message field should use fleet name instead
     const auto transporter_type = msg->transporter_type;
@@ -234,23 +235,23 @@ private:
         {
           RCLCPP_WARN(_node->get_logger(),
             "Request already succeeded: [%s]", request_guid);
-          send_ingestor_response(request_guid, DispenserResult::SUCCESS);
+          send_ingestor_response(request_guid, IngestorResult::SUCCESS);
         }
         else
         {
           RCLCPP_WARN(_node->get_logger(),
             "Request already failed: [%s]", request_guid);
-          send_ingestor_response(request_guid, DispenserResult::FAILED);
+          send_ingestor_response(request_guid, IngestorResult::FAILED);
         }
         return;
       }
 
-      send_ingestor_response(request_guid, DispenserResult::ACKNOWLEDGED);
+      send_ingestor_response(request_guid, IngestorResult::ACKNOWLEDGED);
 
       RCLCPP_INFO(_node->get_logger(), "Ingesting item");
       ingest_from_nearest_robot(transporter_type);
 
-      send_ingestor_response(request_guid, DispenserResult::SUCCESS);
+      send_ingestor_response(request_guid, IngestorResult::SUCCESS);
 
       rclcpp::sleep_for(std::chrono::seconds(10));
       send_ingested_item_home();
@@ -271,7 +272,7 @@ private:
       const auto now = simulation_now();
 
       _current_state.time = now;
-      _current_state.mode = DispenserState::IDLE;
+      _current_state.mode = IngestorState::IDLE;
       _state_pub->publish(_current_state);
     }
   }
@@ -306,22 +307,22 @@ public:
         fleet_state_cb(std::move(msg));
       });
 
-    _state_pub = _node->create_publisher<DispenserState>(
-      "/dispenser_states", 10);
+    _state_pub = _node->create_publisher<IngestorState>(
+      "/ingestor_states", 10);
 
-    _request_sub = _node->create_subscription<DispenserRequest>(
-      "/dispenser_requests",
+    _request_sub = _node->create_subscription<IngestorRequest>(
+      "/ingestor_requests",
       rclcpp::SystemDefaultsQoS(),
-      [&](DispenserRequest::UniquePtr msg)
+      [&](IngestorRequest::UniquePtr msg)
       {
-        dispenser_request_cb(std::move(msg));
+        ingestor_request_cb(std::move(msg));
       });
 
-    _result_pub = _node->create_publisher<DispenserResult>(
-      "/dispenser_results", 10);
+    _result_pub = _node->create_publisher<IngestorResult>(
+      "/ingestor_results", 10);
 
     _current_state.guid = _guid;
-    _current_state.mode = DispenserState::IDLE;
+    _current_state.mode = IngestorState::IDLE;
 
     _update_connection = gazebo::event::Events::ConnectWorldUpdateBegin(
       std::bind(&TeleportIngestorPlugin::on_update, this));

--- a/rmf_rviz_plugin/src/RmfPanel.cpp
+++ b/rmf_rviz_plugin/src/RmfPanel.cpp
@@ -112,9 +112,9 @@ void RmfPanel::create_layout()
   _pickup_dispenser_editor = new QLineEdit;
   delivery_layout->addWidget(_pickup_dispenser_editor, 0, 1, 1, 2);
 
-  delivery_layout->addWidget(new QLabel("Dropoff dispenser: "), 1, 0);
-  _dropoff_dispenser_editor = new QLineEdit;
-  delivery_layout->addWidget(_dropoff_dispenser_editor, 1, 1, 1, 2);
+  delivery_layout->addWidget(new QLabel("Dropoff ingestor: "), 1, 0);
+  _dropoff_ingestor_editor = new QLineEdit;
+  delivery_layout->addWidget(_dropoff_ingestor_editor, 1, 1, 1, 2);
 
   _send_delivery_button = new QPushButton("Send Delivery Request");
   delivery_layout->addWidget(_send_delivery_button, 2, 0, 1, -1);
@@ -383,11 +383,11 @@ void RmfPanel::load(const rviz_common::Config& config)
 {
   rviz_common::Panel::load(config);
   QString pickup_dispenser;
-  QString dropoff_dispenser;
+  QString dropoff_ingestor;
   if (config.mapGetString("pickup_dispenser", &pickup_dispenser))
     _pickup_dispenser_editor->setText(pickup_dispenser);
-  if (config.mapGetString("dropoff_dispenser", &dropoff_dispenser))
-    _dropoff_dispenser_editor->setText(dropoff_dispenser);
+  if (config.mapGetString("dropoff_ingestor", &dropoff_ingestor))
+    _dropoff_ingestor_editor->setText(dropoff_ingestor);
 }
 
 // Save config
@@ -395,7 +395,7 @@ void RmfPanel::save(rviz_common::Config config) const
 {
   rviz_common::Panel::save(config);
   config.mapSetValue("pickup_dispenser", _pickup_dispenser_editor->text());
-  config.mapSetValue("dropoff_dispenser", _dropoff_dispenser_editor->text());
+  config.mapSetValue("dropoff_ingestor", _dropoff_ingestor_editor->text());
 }
 
 // Q_SLOTS
@@ -405,14 +405,14 @@ void RmfPanel::queue_delivery()
   std::string start = _start_waypoint_selector->currentText().toStdString();
   std::string end = _end_waypoint_selector->currentText().toStdString();
   std::string pickup_dispenser = _pickup_dispenser_editor->text().toStdString();
-  std::string dropoff_dispenser =
-    _dropoff_dispenser_editor->text().toStdString();
+  std::string dropoff_ingestor =
+    _dropoff_ingestor_editor->text().toStdString();
 
   Delivery delivery;
 
   // If either start or end are empty, the delivery should probably not be queued
   if (start.empty() || end.empty() || pickup_dispenser.empty()
-    || dropoff_dispenser.empty())
+    || dropoff_ingestor.empty())
   {
     RCLCPP_INFO(_node->get_logger(),
       "Waypoint input is empty string; Delivery not queued in plan.");
@@ -423,7 +423,7 @@ void RmfPanel::queue_delivery()
   delivery.pickup_place_name = start;
   delivery.dropoff_place_name = end;
   delivery.pickup_dispenser = pickup_dispenser;
-  delivery.dropoff_dispenser = dropoff_dispenser;
+  delivery.dropoff_ingestor = dropoff_ingestor;
 
   auto delivery_time = _time_selector->time();
 

--- a/rmf_rviz_plugin/src/RmfPanel.hpp
+++ b/rmf_rviz_plugin/src/RmfPanel.hpp
@@ -134,8 +134,8 @@ protected:
   // Actions - For queuing commands in Plan
   QLineEdit* _pickup_dispenser_editor;
   QString _pickup_dispenser;
-  QLineEdit* _dropoff_dispenser_editor;
-  QString _dropoff_dispenser;
+  QLineEdit* _dropoff_ingestor_editor;
+  QString _dropoff_ingestor;
   QPushButton* _send_delivery_button;
 
   QSpinBox* _repeat_count_selector; // Number of loops in Loop task


### PR DESCRIPTION
Modified the `TeleportIngestorPlugin` to use the newly implemented `rmf_ingestor_msgs` instead of `rmf_dispenser_msgs`. Enables future differentiation between Ingestors and Dispensers if required.