### PR TITLE
Modify moment of inertia tensors for Caddy wheels

### DIFF
--- a/rmf_demo_assets/models/Caddy/model.sdf
+++ b/rmf_demo_assets/models/Caddy/model.sdf
@@ -446,12 +446,12 @@
         <mass>2.6357</mass>
         <!-- estimated from http://www.rzrforums.net/wheels-tires/1729-tire-wheel-weights-most-sizes.html -->
         <inertia>
-          <ixx>0.0246688</ixx>
+          <ixx>0.092</ixx>
           <ixy>0.0</ixy>
-          <iyy>0.0246688</iyy>
+          <iyy>0.092</iyy>
           <ixz>0.0</ixz>
           <iyz>0.0</iyz>
-          <izz>1.0441058</izz>
+          <izz>0.167</izz>
         </inertia>
       </inertial>
       <collision name="collision">
@@ -506,12 +506,12 @@
         <mass>2.6357</mass>
         <!-- estimated from http://www.rzrforums.net/wheels-tires/1729-tire-wheel-weights-most-sizes.html -->
         <inertia>
-          <ixx>0.0246688</ixx>
+          <ixx>0.092</ixx>
           <ixy>0.0</ixy>
-          <iyy>0.0246688</iyy>
+          <iyy>0.092</iyy>
           <ixz>0.0</ixz>
           <iyz>0.0</iyz>
-          <izz>1.0441058</izz>
+          <izz>0.167</izz>
         </inertia>
       </inertial>
       <collision name="collision">
@@ -566,12 +566,12 @@
         <mass>2.6357</mass>
         <!-- estimated from http://www.rzrforums.net/wheels-tires/1729-tire-wheel-weights-most-sizes.html -->
         <inertia>
-          <ixx>0.0246688</ixx>
+          <ixx>0.092</ixx>
           <ixy>0.0</ixy>
-          <iyy>0.0246688</iyy>
+          <iyy>0.092</iyy>
           <ixz>0.0</ixz>
           <iyz>0.0</iyz>
-          <izz>1.0441058</izz>
+          <izz>0.167</izz>
         </inertia>
       </inertial>
       <collision name="collision">
@@ -647,12 +647,12 @@
         <mass>2.6357</mass>
         <!-- estimated from http://www.rzrforums.net/wheels-tires/1729-tire-wheel-weights-most-sizes.html -->
         <inertia>
-          <ixx>0.0246688</ixx>
+          <ixx>0.092</ixx>
           <ixy>0.0</ixy>
-          <iyy>0.0246688</iyy>
+          <iyy>0.092</iyy>
           <ixz>0.0</ixz>
           <iyz>0.0</iyz>
-          <izz>1.0441058</izz>
+          <izz>0.167</izz>
         </inertia>
       </inertial>
       <collision name="collision">


### PR DESCRIPTION
Adjust the inertia values for the 4 wheels in order to satisfy the triangle inequalities for the inertia matrix. Inertia values are
estimated assuming a thick walled solid cylindrical shell shape. Runs smoothly in the current airport terminal demo.