### PR TITLE
Add first pass of quality declarations for all packages

### DIFF
--- a/demos/QUALITY_DECLARATION.md
+++ b/demos/QUALITY_DECLARATION.md
@@ -1,0 +1,198 @@
+This document is a declaration of software quality for the `demos` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `demos` Quality Declaration
+
+The package `demos` claims to be in the **Quality Level 4** category.
+The main rationale for this claim its its status as a collection of demonstration launch files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`demos` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`demos` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`demos` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`demos` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`demos` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`demos` does not have a public API.
+
+## Change Control Process [2]
+
+`demos` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`demos` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`demos` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`demos` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`demos` does not have a public API.
+
+### License [3.iii]
+
+The license for `demos` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`demos` is a package providing strictly launch files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`demos` does not use the [standard linters and static analysis tools](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`demos` has the following runtime ROS dependencies.
+
+#### rmf_demo_maps
+
+`rmf_demo_maps` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_demo_maps/QUALITY_DECLARATION.md).
+
+#### rmf_traffic_ros2
+
+`rmf_traffic_ros2` is at [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic_ros2/QUALITY_DECLARATION.md).
+
+#### rmf_fleet_adapter
+
+`rmf_fleet_adapter` is at [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_adapter/QUALITY_DECLARATION.md).
+
+#### building_map_tools
+
+`building_map_tools` is at [**Quality Level 4**](https://github.com/osrf/traffic_editor/blob/master/building_map_tools/QUALITY_DECLARATION.md).
+
+#### building_gazebo_plugins
+
+`building_gazebo_plugins` is at [**Quality Level 4**](https://github.com/osrf/traffic_editor/building_sim_plugins/blob/master/building_gazebo_plugins/QUALITY_DECLARATION.md).
+
+#### visualizer
+
+`visualizer` is at [**Quality Level 4**](https://github.com/osrf/rmf_schedule_visualizer/blob/master/visualizer/QUALITY_DECLARATION.md).
+
+#### gazebo_ros_pkgs
+
+`gazebo_ros_pkgs` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### rmf_demo_assets
+
+`rmf_demo_assets` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_demo_assets/QUALITY_DECLARATION.md).
+
+#### rmf_gazebo_plugins
+
+`rmf_gazebo_plugins` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_gazebo_plugins/QUALITY_DECLARATION.md).
+
+#### rmf_demo_tasks
+
+`rmf_demo_tasks` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_demo_tasks/QUALITY_DECLARATION.md).
+
+#### rmf_rviz_plugin
+
+`rmf_rviz_plugin` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_rviz_plugin/QUALITY_DECLARATION.md).
+
+#### rviz2
+
+`rviz2` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### joy
+
+`joy` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### teleop_twist_joy
+
+`teleop_twist_joy` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### launch_xml
+
+`launch_xml` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`demos` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`demos` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure message and service definitions package, `demos` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,7 @@
+# demos
+
+This package provides launch files and shell scripts demonstrating how to build and start systems using RMF.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_dashboard_resources/QUALITY_DECLARATION.md
+++ b/rmf_dashboard_resources/QUALITY_DECLARATION.md
@@ -1,0 +1,132 @@
+This document is a declaration of software quality for the `rmf_dashboard_resources` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_dashboard_resources` Quality Declaration
+
+The package `rmf_dashboard_resources` claims to be in the **Quality Level 3** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_dashboard_resources` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_dashboard_resources` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_dashboard_resources` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_dashboard_resources` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_dashboard_resources` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_dashboard_resources` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_dashboard_resources` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_dashboard_resources` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_dashboard_resources` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_dashboard_resources` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_dashboard_resources` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_dashboard_resources` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_dashboard_resources` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_dashboard_resources` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_dashboard_resources` does not have any required direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_dashboard_resources` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_dashboard_resources` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_dashboard_resources` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_dashboard_resources/README.md
+++ b/rmf_dashboard_resources/README.md
@@ -1,0 +1,7 @@
+# rmf\_dashboard\_resources
+
+This package provides resources for the RMF dashboard.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demo_assets/QUALITY_DECLARATION.md
+++ b/rmf_demo_assets/QUALITY_DECLARATION.md
@@ -1,0 +1,141 @@
+This document is a declaration of software quality for the `rmf_demo_assets` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_assets` Quality Declaration
+
+The package `rmf_demo_assets` claims to be in the **Quality Level 3** category.
+The main rationale for this claim its its status as a collection of demonstration model files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_assets` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_assets` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_assets` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_assets` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_assets` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_assets` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_assets` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_assets` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_assets` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_assets` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_assets` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_assets` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_assets` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_assets` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_assets` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demo_assets` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_assets` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_assets` has the following direct runtime ROS dependencies.
+
+#### rmf_gazebo_plugins
+
+`rmf_gazebo_plugins` is at [**Quality Level 4**](https://github.com/osrf/rmf_demos/blob/master/rmf_gazebo_plugins/QUALITY_DECLARATION.md).
+
+#### building_gazebo_plugins
+
+`building_gazebo_plugins` is at [**Quality Level 4**](https://github.com/osrf/traffic_editor/building_sim_plugins/blob/master/building_gazebo_plugins/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_assets` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_assets` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demo_assets` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demo_assets/README.md
+++ b/rmf_demo_assets/README.md
@@ -1,0 +1,7 @@
+# rmf\_demo\_assets
+
+This package provides simulator models for the RMF demos.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demo_maps/QUALITY_DECLARATION.md
+++ b/rmf_demo_maps/QUALITY_DECLARATION.md
@@ -1,0 +1,133 @@
+This document is a declaration of software quality for the `rmf_demo_maps` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_maps` Quality Declaration
+
+The package `rmf_demo_maps` claims to be in the **Quality Level 3** category.
+The main rationale for this claim its its status as a collection of demonstration map files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_maps` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_maps` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_maps` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_maps` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_maps` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_maps` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_maps` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_maps` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_maps` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_maps` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_maps` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_maps` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+There are no source files that are currently copyrighted in this package so files are not checked for abbreviated license statements.
+
+### Copyright Statement [3.iv]
+
+There are no copyrighted source files in this package.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 3 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demo_maps` is a package providing strictly resource files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_maps` has no files that require linting or static analysis.
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_maps` does not have any required direct runtime ROS dependencies.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_maps` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_maps` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demo_maps` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demo_maps/README.md
+++ b/rmf_demo_maps/README.md
@@ -1,0 +1,7 @@
+# rmf\_demo\_maps
+
+This package provides maps for the RMF demos.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 3** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_demo_tasks/QUALITY_DECLARATION.md
+++ b/rmf_demo_tasks/QUALITY_DECLARATION.md
@@ -1,0 +1,147 @@
+This document is a declaration of software quality for the `rmf_demo_tasks` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_demo_tasks` Quality Declaration
+
+The package `rmf_demo_tasks` claims to be in the **Quality Level 4** category.
+The main rationale for this claim its its status as a collection of demonstration script files.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_demo_tasks` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_demo_tasks` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_demo_tasks` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_demo_tasks` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_demo_tasks` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_demo_tasks` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_demo_tasks` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_demo_tasks` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_demo_tasks` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_demo_tasks` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_demo_tasks` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_demo_tasks` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Public API Testing [4.ii]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Coverage [4.iii]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Performance [4.iv]
+
+`rmf_demo_tasks` is a package providing strictly demonstration script files and therefore does not require associated tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_demo_tasks` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_demo_tasks` has the following direct runtime ROS dependencies.
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_task\_msgs
+
+`rmf_task_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_task_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_list_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_dispenser\_msgs
+
+`rmf_dispenser_msgs`` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_dispenser_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_demo_tasks` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_demo_tasks` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+As a pure resource package, `rmf_demo_tasks` supports all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers), but does not currently test each change against all of them.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_demo_tasks/README.md
+++ b/rmf_demo_tasks/README.md
@@ -1,0 +1,7 @@
+# rmf\_demo\_tasks
+
+This package provides scripts used in the RMF demos to demonstrate the tasks that may be requested of a robot.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_gazebo_plugins/QUALITY_DECLARATION.md
+++ b/rmf_gazebo_plugins/QUALITY_DECLARATION.md
@@ -1,0 +1,160 @@
+This document is a declaration of software quality for the `rmf_gazebo_plugins` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_gazebo_plugins` Quality Declaration
+
+The package `rmf_gazebo_plugins` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_gazebo_plugins` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_gazebo_plugins` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_gazebo_plugins` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_gazebo_plugins` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_gazebo_plugins` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_gazebo_plugins` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_gazebo_plugins` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_gazebo_plugins` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`rmf_gazebo_plugins` does not have a public API.
+
+### Coverage [4.iii]
+
+`rmf_gazebo_plugins` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_gazebo_plugins` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_gazebo_plugins` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_gazebo_plugins` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### gazebo_ros_pkgs
+
+`gazebo_ros_pkgs` does not declare a Quality Level.
+It is assumed tobe at **Quality Level 4** based on its widespread use.
+
+#### std_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_dispenser\_msgs
+
+`rmf_dispenser_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_dispenser_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_ingestor\_msgs
+
+`rmf_ingestor_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_ingestor_msgs/QUALITY_DECLARATION.md).
+
+#### building\_map\_msgs
+
+`building_map_msgs` is [**Quality Level 3**](https://github.com/osrf/traffic_editor/blob/master/building_map_msgs/QUALITY_DECLARATION.md).
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_gazebo_plugins` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_gazebo_plugins` does not have any runtime non-ROS dependencies.
+
+## Platform Support [6]
+
+`rmf_gazebo_plugins` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_gazebo_plugins` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_gazebo_plugins/README.md
+++ b/rmf_gazebo_plugins/README.md
@@ -1,0 +1,7 @@
+# rmf\_gazebo\_plugins
+
+This package provides Gazebo simulator plugins for the building infrastructure used by the RMF demos.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rmf_rviz_plugin/QUALITY_DECLARATION.md
+++ b/rmf_rviz_plugin/QUALITY_DECLARATION.md
@@ -1,0 +1,208 @@
+This document is a declaration of software quality for the `rmf_rviz_plugin` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+# `rmf_rviz_plugin` Quality Declaration
+
+The package `rmf_rviz_plugin` claims to be in the **Quality Level 4** category.
+
+Below are the detailed rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+
+## Version Policy [1]
+
+### Version Scheme [1.i]
+
+`rmf_rviz_plugin` uses `semver` according to the recommendation for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#versioning).
+
+### Version Stability [1.ii]
+
+`rmf_rviz_plugin` is at a stable version, i.e. `>= 1.0.0`.
+The current version can be found in its [package.xml](package.xml), and its change history can be found in its [CHANGELOG](CHANGELOG.rst).
+
+### Public API Declaration [1.iii]
+
+`rmf_rviz_plugin` does not have a public API.
+
+### API Stability Policy [1.iv]
+
+`rmf_rviz_plugin` does not have a public API.
+
+### ABI Stability Policy [1.v]
+
+`rmf_rviz_plugin` does not have a public API.
+
+### API and ABI Stability Within a Released ROS Distribution [1.vi]
+
+`rmf_rviz_plugin` does not have a public API.
+
+## Change Control Process [2]
+
+`rmf_rviz_plugin` follows the recommended guidelines for ROS Core packages in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#package-requirements).
+
+### Change Requests [2.i]
+
+`rmf_rviz_plugin` requires that all changes occur through a pull request.
+
+### Contributor Origin [2.ii]
+
+`rmf_rviz_plugin` does not require a confirmation of contributor origin.
+
+### Peer Review Policy [2.iii]
+
+All pull requests must have at least 1 peer review.
+
+### Continuous Integration [2.iv]
+
+All pull requests must pass CI on all platforms supported by RMF.
+The CI checks only that the package builds.
+The most recent CI results can be seen on [the workflow page](https://github.com/osrf/rmf_demos/actions).
+
+### Documentation Policy [2.v]
+
+All pull requests must resolve related documentation changes before merging.
+
+## Documentation [3]
+
+### Feature Documentation [3.i]
+
+`rmf_rviz_plugin` is documented in the [parent repository's README.md file](https://github.com/osrf/rmf_demos/blob/master/README.md).
+
+### Public API Documentation [3.ii]
+
+`rmf_rviz_plugin` does not have a public API.
+
+### License [3.iii]
+
+The license for `rmf_rviz_plugin` is Apache 2.0, the type is declared in the [package.xml](package.xml) manifest file, and a full copy of the license is in the repository level [LICENSE](../LICENSE) file.
+
+### Copyright Statement [3.iv]
+
+The copyright holders each provide a statement of copyright in each source code file in `rmf_demo_tasks`.
+
+### Quality declaration document [3.v]
+
+This quality declaration is linked in the [README file](README.md).
+
+This quality declaration has not been externally peer-reviewed and is not registered on any Level 4 lists.
+
+## Testing [4]
+
+### Feature Testing [4.i]
+
+`rmf_rviz_plugin` does not have any tests.
+
+### Public API Testing [4.ii]
+
+`rmf_rviz_plugin` does not have a public API.
+
+### Coverage [4.iii]
+
+`rmf_rviz_plugin` does not track coverage statistics.
+
+### Performance [4.iv]
+
+`rmf_rviz_plugin` does not have performance tests.
+
+### Linters and Static Analysis [4.v]
+
+`rmf_rviz_plugin` does not use the standard linters and static analysis tools for its CMake code to ensure it follows the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
+
+## Dependencies [5]
+
+### Direct Runtime ROS Dependencies [5.i]
+
+`rmf_rviz_plugin` has the following direct runtime ROS dependencies.
+
+#### rclcpp
+
+`rclcpp` is [**Quality Level 3**](https://github.com/ros2/rclcpp/blob/master/rclcpp/QUALITY_DECLARATION.md).
+
+#### std_msgs
+
+`std_msgs` is [**Quality Level 3**](https://github.com/ros2/common_interfaces/blob/master/std_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_fleet\_msgs
+
+`rmf_fleet_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_fleet_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_dispenser\_msgs
+
+`rmf_dispenser_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_dispenser_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_door\_msgs
+
+`rmf_door_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_door_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_lift\_msgs
+
+`rmf_lift_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_lift_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_task\_msgs
+
+`rmf_task_msgs` is [**Quality Level 3**](https://github.com/osrf/rmf_core/blob/master/rmf_task_msgs/QUALITY_DECLARATION.md).
+
+#### rmf\_traffic
+
+`rmf_traffic` is [**Quality Level 4**](https://github.com/osrf/rmf_core/blob/master/rmf_traffic/QUALITY_DECLARATION.md).
+
+#### rviz\_common
+
+`rviz_common` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### rviz\_default\_plugins
+
+`rviz_default_plugins` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### rviz\_rendering
+
+`rviz_rendering` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### pluginlib
+
+`pluginlib` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+#### resource_retriever
+
+`resource_retriever` does not declare a Quality Level.
+It is assumed to be at **Quality Level 4** based on its widespread use.
+
+### Optional Direct Runtime ROS Dependencies [5.ii]
+
+`rmf_rviz_plugin` does not have any optional direct runtime ROS dependencies.
+
+### Direct Runtime non-ROS Dependency [5.iii]
+
+`rmf_rviz_plugin` has the following runtime non-ROS dependencies.
+
+#### qtbase5-dev
+
+`qtbase5-dev` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-core
+
+`libqt5-core` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-gui
+
+`libqt5-gui` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+#### libqt5-widgets
+
+`libqt5-widgets` is widely-used third-party software for building graphical applications.
+Due to its wide use, documentation, and testing, it is assumed to be **Quality Level 3**.
+
+## Platform Support [6]
+
+`rmf_rviz_plugin` does not support all of the tier 1 platforms as described in [REP-2000](https://www.ros.org/reps/rep-2000.html#support-tiers).
+`rmf_rviz_plugin` supports ROS Eloquent and ROS Foxy.
+
+## Security [7]
+
+### Vulnerability Disclosure Policy [7.i]
+
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rmf_rviz_plugin/README.md
+++ b/rmf_rviz_plugin/README.md
@@ -1,0 +1,7 @@
+# rmf\_rviz\_plugin
+
+This package provides plugins for `rviz` to visualize and control the RMF demos.
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
This PR adds [quality declaration documents](https://www.ros.org/reps/rep-2004.html) and (where necessary) basic README files too all packages in `rmf_core`.

The resource packages meet the requirements to be Quality Level 3. All source-code-containing packages are currently QL4.

We need to go over each declaration and discuss it, making sure we all agree on the arguments being made.

Once this PR goes in, we can make a list of tasks that need to be done to move the packages up to higher quality levels.