### PR TITLE
Add menge library to repos

### DIFF
--- a/rmf_demos.repos
+++ b/rmf_demos.repos
@@ -19,3 +19,7 @@ repositories:
     type: git
     url: https://github.com/osrf/rmf_demos.git
     version: master
+  thirdparty/menge_core:
+    type: git
+    url: https://github.com/osrf/menge_core.git
+    version: master


### PR DESCRIPTION
Added the menge library for crowd simulation as a package to be built from source by vcs.