### PR TITLE
Adjust TinyRobot mass to run smoothly using DART on Ignition

### DIFF
--- a/rmf_demo_assets/models/TinyRobot/model.sdf
+++ b/rmf_demo_assets/models/TinyRobot/model.sdf
@@ -24,7 +24,7 @@
       <pose frame=''>0 0 0 0 -0 0</pose>
       <inertial>
         <pose frame=''>-0.15 0 0.13 0 -0 0</pose>
-        <mass>10</mass>
+        <mass>7</mass> <!-- A higher mass causes wheels to spin while attempting to turn when using DART -->
         <inertia>
           <ixx>0.0594508</ixx>
           <ixy>0</ixy>


### PR DESCRIPTION
Currently, the wheels of the TinyRobot slip in Ignition with the DART physics engine when attempting to turn. This fix modifies the mass slightly for now, to allow it to run smoothly.