### PR TITLE
fixup value for CMAKE_BUILD_TYPE

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,4 +44,4 @@ jobs:
       run: |
         cd rmf_demos_ws
         source /opt/ros/foxy/setup.bash
-        colcon build --cmake-args -DCMAKE_BUILD_TYPE=RELEASE -DNO_DOWNLOAD_MODELS=True
+        colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DNO_DOWNLOAD_MODELS=True

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -60,7 +60,7 @@ The models required for each of the demo worlds will be automatically downloaded
 ```bash
 cd ~/rmf_demos_ws
 source /opt/ros/foxy/setup.bash
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=RELEASE
+colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 NOTE: The first time the build occurs, many simulation models will be downloaded from Ignition Fuel to populate the scene when the simulation is run.
@@ -77,6 +77,6 @@ sudo apt install g++-8 libignition-common3-dev libignition-plugin-dev -y
 ```bash
 cd ~/rmf_demos_ws
 source ~/ros2_foxy/install/setup.bash
-CXX=g++-8 colcon build --cmake-args -DCMAKE_BUILD_TYPE=RELEASE
+CXX=g++-8 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 > Note: The build will fail if the compiler is not set to g++ version 8 or above.


### PR DESCRIPTION
As per CMake docs, allowed values have CamelCase:
> This statically specifies what build type (configuration) will be built in this build tree. Possible values are empty, Debug, Release, RelWithDebInfo, MinSizeRel, … 

Although using a different case allows to build with the optimization flags, it may conflict with CMake logic of other packages in the workspace that are looking for the official valid values and may not support a different case for them