### PR TITLE
Fix Gazebo crash with both Ignition and Gazebo diff drive plugins in same file

### DIFF
--- a/rmf_demo_assets/models/Caddy/model.sdf
+++ b/rmf_demo_assets/models/Caddy/model.sdf
@@ -64,9 +64,10 @@
       <robot_base_frame>chassis</robot_base_frame>
     </plugin>
 
-    <!-- Causes protobuf crashes when launching gazebo, TODO find a way to launch the system only in ignition -->
-    <!--
-    <plugin name="ignition::gazebo::systems::DiffDrive" filename="libignition-gazebo4-diff-drive-system.so">
+    <!-- Note: The forward slash before `libignition-gazebo4-diff-drive-system.so` is necessary so that
+    `dlopen` in Gazebo Classic interprets it as a pathname and avoids searching LD_LIBRARY_PATH for the
+    plugin. If omitted, Gazebo Classic will locate the ignition plugin and crash while attempting to load it. -->
+    <plugin name="ignition::gazebo::systems::DiffDrive" filename="/libignition-gazebo4-diff-drive-system.so">
       <always_on>true</always_on>
       <update_rate>100.0</update_rate>
       <num_wheel_pairs>2</num_wheel_pairs>
@@ -92,7 +93,6 @@
       <odometry_frame>odom</odometry_frame>
       <robot_base_frame>chassis</robot_base_frame>
     </plugin>
-    -->
 
     <link name="chassis">
       <inertial>

--- a/rmf_demo_plugins/rmf_ignition_plugins/CHANGELOG.rst
+++ b/rmf_demo_plugins/rmf_ignition_plugins/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog for package rmf_ignition_plugins
 
 Forthcoming
 -----------
-* Provides `TeleportDispenserPlugin` Ingestor plugin that is attached to the `TeleportDispenser` model in `rmf_demo_assets`. When loaded into Ignition Gazebo along side a "payload" model, the plugin will teleport the payload onto the nearest robot when it registers a `rmf_dispenser_msgs::DispenserRequest` message with `target_guid` matching its model name.
-* Provides `TeleportIngestorPlugin` Ingestor plugin that is attached to the `TeleportIngestor` model in `rmf_demo_assets`. When loaded into Ignition Gazebo, the plugin will teleport the payload off the nearest robot and onto its location, when it registers a `rmf_ingestor_msgs::IngestorRequest` message with `target_guid` matching its model name.
+* Provides `TeleportDispenserPlugin` Ignition plugin that is attached to the `TeleportDispenser` model in `rmf_demo_assets`. When loaded into Ignition Gazebo along side a "payload" model, the plugin will teleport the payload onto the nearest robot when it registers a `rmf_dispenser_msgs::DispenserRequest` message with `target_guid` matching its model name.
+* Provides `TeleportIngestorPlugin` Ignition plugin that is attached to the `TeleportIngestor` model in `rmf_demo_assets`. When loaded into Ignition Gazebo, the plugin will teleport the payload off the nearest robot and onto its location, when it registers a `rmf_ingestor_msgs::IngestorRequest` message with `target_guid` matching its model name.
 * Provides `ReadonlyPlugin` Readonly plugin that emulates the behavior of a `read_only` fleet type. When attached to a steerable vehicle that operates on a known traffic graph, the plugin publishes a prediction of the vehicle's intended path to the `rmf traffic database` via its configured `read_only_fleet_adapter`. Other fleets operating in the space can plan routes to avoid the path of this vehicle.
 * Contributors: Aaron Chong, Luca Della Vedova, Yadunund, Rushyendra Maganty


### PR DESCRIPTION
Gazebo uses `dlopen` to search for and load plugins. Adding a forward slash before the plugin filename ensures that `dlopen` interprets it as a pathname, avoiding crashes since Gazebo classic will no longer be able to find and load the ignition plugin.