### PR TITLE
fix dispenser and ingestor results

### DIFF
--- a/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
@@ -111,7 +111,7 @@ void TeleportDispenserCommon::on_update(
   if (sim_time - last_pub_time >= interval || dispense)
   {
     last_pub_time = sim_time;
-    current_state.time = simulation_now(sim_time);;
+    current_state.time = simulation_now(sim_time);
 
     if (dispense)
     {
@@ -126,12 +126,12 @@ void TeleportDispenserCommon::on_update(
     _state_pub->publish(current_state);
   }
 
-  // `dispense` is set to true if the dispenser plugin node has 
+  // `dispense` is set to true if the dispenser plugin node has
   // received a valid DispenserRequest
   if (dispense)
   {
     send_dispenser_response(DispenserResult::ACKNOWLEDGED);
-    
+
     bool is_success = false;
     if (dispenser_filled)
     {
@@ -158,8 +158,8 @@ void TeleportDispenserCommon::on_update(
       send_dispenser_response(DispenserResult::FAILED);
     }
 
-    _past_request_guids.insert(std::pair<std::string,bool>(
-      latest.request_guid, is_success));
+    _past_request_guids.insert(std::pair<std::string, bool>(
+        latest.request_guid, is_success));
 
     dispense = false;
   }

--- a/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
@@ -21,21 +21,22 @@ void TeleportDispenserCommon::dispenser_request_cb(
 {
   latest = *msg;
 
-  if (guid == latest.target_guid && dispenser_filled)
+  if (guid == latest.target_guid)
   {
+    // check if task has been completed previously
     const auto it = _past_request_guids.find(latest.request_guid);
     if (it != _past_request_guids.end())
     {
       if (it->second)
       {
         RCLCPP_WARN(ros_node->get_logger(),
-          "Request already succeeded: [%s]", latest.request_guid);
+          "Request already succeeded: [%s]", latest.request_guid.c_str());
         send_dispenser_response(DispenserResult::SUCCESS);
       }
       else
       {
         RCLCPP_WARN(ros_node->get_logger(),
-          "Request already failed: [%s]", latest.request_guid);
+          "Request already failed: [%s]", latest.request_guid.c_str());
         send_dispenser_response(DispenserResult::FAILED);
       }
       return;
@@ -103,11 +104,35 @@ void TeleportDispenserCommon::on_update(
   std::function<void(const SimEntity&)> place_on_entity_cb,
   std::function<bool(void)> check_filled_cb)
 {
-  // `_dispense` is set to true if the dispenser plugin node has received a valid DispenserRequest
+  try_refill_dispenser(check_filled_cb);
+
+  // periodic pub on dispenser state
+  constexpr double interval = 2.0;
+  if (sim_time - last_pub_time >= interval || dispense)
+  {
+    last_pub_time = sim_time;
+    current_state.time = simulation_now(sim_time);;
+
+    if (dispense)
+    {
+      current_state.mode = DispenserState::BUSY;
+      current_state.request_guid_queue = {latest.request_guid};
+    }
+    else
+    {
+      current_state.mode = DispenserState::IDLE;
+      current_state.request_guid_queue.clear();
+    }
+    _state_pub->publish(current_state);
+  }
+
+  // `dispense` is set to true if the dispenser plugin node has 
+  // received a valid DispenserRequest
   if (dispense)
   {
     send_dispenser_response(DispenserResult::ACKNOWLEDGED);
-
+    
+    bool is_success = false;
     if (dispenser_filled)
     {
       RCLCPP_INFO(ros_node->get_logger(), "Dispensing item");
@@ -116,6 +141,7 @@ void TeleportDispenserCommon::on_update(
           latest.transporter_type);
       if (res)
       {
+        is_success = true;
         send_dispenser_response(DispenserResult::SUCCESS);
         RCLCPP_INFO(ros_node->get_logger(), "Success");
       }
@@ -128,23 +154,14 @@ void TeleportDispenserCommon::on_update(
     else
     {
       RCLCPP_WARN(ros_node->get_logger(),
-        "No item to dispense: [%s]", latest.request_guid);
+        "No item to dispense: [%s]", latest.request_guid.c_str());
       send_dispenser_response(DispenserResult::FAILED);
     }
+
+    _past_request_guids.insert(std::pair<std::string,bool>(
+      latest.request_guid, is_success));
+
     dispense = false;
-  }
-
-  try_refill_dispenser(check_filled_cb);
-
-  constexpr double interval = 2.0;
-  if (sim_time - last_pub_time >= interval)
-  {
-    last_pub_time = sim_time;
-    const auto now = simulation_now(sim_time);
-
-    current_state.time = now;
-    current_state.mode = DispenserState::IDLE;
-    _state_pub->publish(current_state);
   }
 }
 
@@ -163,7 +180,7 @@ void TeleportDispenserCommon::init_ros_node(const rclcpp::Node::SharedPtr node)
 
   _request_sub = ros_node->create_subscription<DispenserRequest>(
     "/dispenser_requests",
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().reliable(),
     std::bind(&TeleportDispenserCommon::dispenser_request_cb, this,
     std::placeholders::_1));
 

--- a/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/dispenser_common.cpp
@@ -158,8 +158,7 @@ void TeleportDispenserCommon::on_update(
       send_dispenser_response(DispenserResult::FAILED);
     }
 
-    _past_request_guids.insert(std::pair<std::string, bool>(
-        latest.request_guid, is_success));
+    _past_request_guids.emplace(latest.request_guid, is_success);
 
     dispense = false;
   }

--- a/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
@@ -145,8 +145,7 @@ void TeleportIngestorCommon::on_update(
       send_ingestor_response(IngestorResult::FAILED);
     }
 
-    _past_request_guids.insert(std::pair<std::string, bool>(
-        latest.request_guid, is_success));
+    _past_request_guids.emplace(latest.request_guid, is_success);
 
     ingest = false;
   }

--- a/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
@@ -28,13 +28,13 @@ void TeleportIngestorCommon::ingestor_request_cb(IngestorRequest::UniquePtr msg)
       if (it->second)
       {
         RCLCPP_WARN(ros_node->get_logger(),
-          "Request already succeeded: [%s]", latest.request_guid);
+          "Request already succeeded: [%s]", latest.request_guid.c_str());
         send_ingestor_response(IngestorResult::SUCCESS);
       }
       else
       {
         RCLCPP_WARN(ros_node->get_logger(),
-          "Request already failed: [%s]", latest.request_guid);
+          "Request already failed: [%s]", latest.request_guid.c_str());
         send_ingestor_response(IngestorResult::FAILED);
       }
       return;
@@ -94,10 +94,31 @@ void TeleportIngestorCommon::on_update(
   std::function<void()> transport_model_cb,
   std::function<void(void)> send_ingested_item_home_cb)
 {
+  // periodic ingestor status publisher
+  constexpr double interval = 2.0;
+  if (sim_time - last_pub_time >= interval || ingest)
+  {
+    last_pub_time = sim_time;
+    current_state.time = simulation_now(sim_time);
+
+    if (ingest)
+    {
+      current_state.mode = IngestorState::BUSY;
+      current_state.request_guid_queue = {latest.request_guid};
+    }
+    else
+    {
+      current_state.mode = IngestorState::IDLE;
+      current_state.request_guid_queue.clear();
+    }
+    _state_pub->publish(current_state);
+  }
+
   if (ingest)
   {
     send_ingestor_response(IngestorResult::ACKNOWLEDGED);
 
+    bool is_success = false;
     if (!ingestor_filled)
     {
       RCLCPP_INFO(ros_node->get_logger(), "Ingesting item");
@@ -108,6 +129,7 @@ void TeleportIngestorCommon::on_update(
       {
         send_ingestor_response(IngestorResult::SUCCESS);
         last_ingested_time = sim_time;
+        is_success = true;
         RCLCPP_INFO(ros_node->get_logger(), "Success");
       }
       else
@@ -122,18 +144,11 @@ void TeleportIngestorCommon::on_update(
         "No item to ingest: [%s]", latest.request_guid);
       send_ingestor_response(IngestorResult::FAILED);
     }
+
+    _past_request_guids.insert(std::pair<std::string,bool>(
+      latest.request_guid, is_success));
+
     ingest = false;
-  }
-
-  constexpr double interval = 2.0;
-  if (sim_time - last_pub_time >= interval)
-  {
-    last_pub_time = sim_time;
-    const auto now = simulation_now(sim_time);
-
-    current_state.time = now;
-    current_state.mode = IngestorState::IDLE;
-    _state_pub->publish(current_state);
   }
 
   // Periodically try to teleport ingested item back to original location
@@ -160,7 +175,7 @@ void TeleportIngestorCommon::init_ros_node(const rclcpp::Node::SharedPtr node)
 
   _request_sub = ros_node->create_subscription<IngestorRequest>(
     "/ingestor_requests",
-    rclcpp::SystemDefaultsQoS(),
+    rclcpp::SystemDefaultsQoS().reliable(),
     std::bind(&TeleportIngestorCommon::ingestor_request_cb, this,
     std::placeholders::_1));
 

--- a/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
+++ b/rmf_demo_plugins/rmf_plugins_common/src/ingestor_common.cpp
@@ -145,8 +145,8 @@ void TeleportIngestorCommon::on_update(
       send_ingestor_response(IngestorResult::FAILED);
     }
 
-    _past_request_guids.insert(std::pair<std::string,bool>(
-      latest.request_guid, is_success));
+    _past_request_guids.insert(std::pair<std::string, bool>(
+        latest.request_guid, is_success));
 
     ingest = false;
   }


### PR DESCRIPTION
This fix is to address the issue which the robot will occasionally get stuck during a "dispensing phase". This can be observed in the office world, which `TinyRobot` will get stuck at the pantry although the dispenser task can be seen as completed. This issue happens much frequently when the simulation is sped up. Msg drop might also be the culprit. 

Here the workcells will store a list of previously completed tasks. Also, `DispenserState` and `IngestorState` are further populated to reflect the actual workcell status.
