### PR TITLE
Fix launch argument

### DIFF
--- a/demos/launch/simulation.launch.xml
+++ b/demos/launch/simulation.launch.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' ?>
 
 <launch>
-  <arg name="map_name" help="Name of the rmf_demos map to simulate" />
+  <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_ignition" default="0" />
 
   <!-- Gazebo classic was chosen-->


### PR DESCRIPTION
Following the changes made in this [PR](https://github.com/ros2/launch/pull/468), `help` is an "Unexpected attribute" and will cause a `ValueError` to be raised. 