### PR TITLE
fix/Dashboard config for rmf_demo_panel

### DIFF
--- a/demos/launch/airport_terminal.launch.xml
+++ b/demos/launch/airport_terminal.launch.xml
@@ -9,6 +9,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/airport_terminal/airport_terminal.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/airport_terminal/airport_terminal.building.yaml"/>
+    <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/airport_terminal/dashboard_config.json"/>
   </include>
 
   <!-- Simulation launch -->
@@ -63,4 +64,3 @@
   </group>
 
 </launch>
-

--- a/demos/launch/clinic.launch.xml
+++ b/demos/launch/clinic.launch.xml
@@ -9,6 +9,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/clinic/clinic.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/clinic/clinic.building.yaml"/>
+    <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/clinic/dashboard_config.json"/>
   </include>
 
   <!-- Simulation launch -->

--- a/demos/launch/common.launch.xml
+++ b/demos/launch/common.launch.xml
@@ -5,6 +5,7 @@
   <arg name="use_sim_time" default="false" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="viz_config_file" default="$(find-pkg-share rmf_schedule_visualizer)/config/rmf.rviz"/>
   <arg name="config_file" description="Building description file required by building_map_tools"/>
+  <arg name="dashboard_config_file" default="" description="Path to dashboard config for web rmf panel file"/>
   <arg name="headless" description="do not launch rviz; launch gazebo in headless mode" default="false"/>
   <arg name="bidding_time_window" description="Time window in seconds for task bidding process" default="2.0"/>
 
@@ -53,6 +54,8 @@
 
   <include file="$(find-pkg-share demos)/dashboard.launch.xml">
     <arg name="use_sim_time" value="true"/>
+    <arg name="dashboard_config_file" value ="$(var dashboard_config_file)"/>
+    <arg name="bidding_time_window" value="$(var bidding_time_window)"/>
   </include>
 
 </launch>

--- a/demos/launch/dashboard.launch.xml
+++ b/demos/launch/dashboard.launch.xml
@@ -4,6 +4,7 @@
 <launch>
   <arg name="use_sim_time" default="true" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="server_ip" default="0.0.0.0" description="GUI IP address"/>
+  <arg name="dashboard_config_file" default="" description="Path to dashboard config for web rmf panel file"/>
 
   <!-- Dispatcher API Server -->
   <group>
@@ -17,6 +18,7 @@
   <group>
     <node pkg="rmf_demo_panel" exec="gui_server"  output="screen">
       <env name="WEB_SERVER_IP_ADDRESS" value="$(var server_ip)" />
+      <env name="DASHBOARD_CONFIG_PATH" value="$(var dashboard_config_file)" />
     </node>
   </group>
 

--- a/demos/launch/hotel.launch.xml
+++ b/demos/launch/hotel.launch.xml
@@ -9,6 +9,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/hotel/hotel.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/hotel/hotel.building.yaml"/>
+    <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/hotel/dashboard_config.json"/>
   </include>
 
   <!-- Simulation launch -->

--- a/demos/launch/office.launch.xml
+++ b/demos/launch/office.launch.xml
@@ -9,6 +9,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/office/office.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/office/office.building.yaml"/>
+    <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/office/dashboard_config.json"/>
   </include>
 
   <!-- Simulation launch -->

--- a/demos/launch/office_mock_traffic_light.launch.xml
+++ b/demos/launch/office_mock_traffic_light.launch.xml
@@ -9,6 +9,7 @@
     <arg name="use_sim_time" value="true"/>
     <arg name="viz_config_file" value ="$(find-pkg-share demos)/include/office/office.rviz"/>
     <arg name="config_file" value="$(find-pkg-share rmf_demo_maps)/office/office.building.yaml"/>
+    <arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/office/dashboard_config.json"/>
   </include>
 
   <!-- Simulation launch -->

--- a/rmf_dashboard_resources/CMakeLists.txt
+++ b/rmf_dashboard_resources/CMakeLists.txt
@@ -30,5 +30,7 @@ add_custom_target(build ALL DEPENDS ${outputs})
 install(DIRECTORY
   airport_terminal
   office
+  hotel
+  clinic
   DESTINATION share/${PROJECT_NAME}
 )

--- a/rmf_dashboard_resources/airport_terminal/dashboard_config.json
+++ b/rmf_dashboard_resources/airport_terminal/dashboard_config.json
@@ -1,4 +1,5 @@
 { 
+  "world_name" : "Airport Terminal World",
   "valid_task" : ["Delivery", "Clean", "Loop"],
   "task": {
     "Delivery": {
@@ -15,8 +16,13 @@
       "places": [
         "koi_pond",
         "west_koi_pond",
+        "east_koi_pond",
+        "s03",
+        "s07",
+        "s08",
         "n01",
         "n08",
+        "n13",
         "n23",
         "n24",
         "n25"

--- a/rmf_dashboard_resources/clinic/dashboard_config.json
+++ b/rmf_dashboard_resources/clinic/dashboard_config.json
@@ -1,4 +1,5 @@
 { 
+  "world_name" : "Clinic World",
   "valid_task" : ["Clean", "Loop"],
   "task": {
     "Delivery": {},

--- a/rmf_dashboard_resources/hotel/dashboard_config.json
+++ b/rmf_dashboard_resources/hotel/dashboard_config.json
@@ -1,4 +1,5 @@
 { 
+  "world_name" : "Hotel World",
   "valid_task" : ["Loop"],
   "task": {
     "Delivery": {},

--- a/rmf_dashboard_resources/office/dashboard_config.json
+++ b/rmf_dashboard_resources/office/dashboard_config.json
@@ -1,8 +1,6 @@
 {
-  "valid_task": [
-    "Delivery",
-    "Loop"
-  ],
+  "world_name" : "Office World",  
+  "valid_task": ["Delivery", "Loop"],
   "task": {
     "Delivery": {
       "option": {

--- a/rmf_demo_panel/package.xml
+++ b/rmf_demo_panel/package.xml
@@ -4,11 +4,12 @@
   <name>rmf_demo_panel</name>
   <version>1.0.0</version>
   <description>Web based RMF Demo Panel</description>
-  <maintainer email="youliang@openrobotics.org">yadu</maintainer>
+  <maintainer email="youliang@openrobotics.org">youliang</maintainer>
   <license>Apache License 2.0</license>
 
-  <exec_depend>building_map_msgs</exec_depend>
   <exec_depend>rmf_fleet_msgs</exec_depend>
+  <exec_depend>rmf_task_msgs</exec_depend>
+  <exec_depend>rmf_demos_dashboard_resources</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/rmf_demo_panel/rmf_demo_panel/gui_server.py
+++ b/rmf_demo_panel/rmf_demo_panel/gui_server.py
@@ -14,18 +14,27 @@
 # limitations under the License.
 
 
-from flask import Flask, render_template
+from flask import Flask, render_template, jsonify
 import os
 import sys
 import requests
+import json 
+
+###############################################################################
 
 app = Flask(__name__, static_url_path="/static")
-
+dashboard_config = {"world_name": ""}
 
 @app.route("/")
 def home():
     return render_template("index.html")
 
+@app.route("/dashboard_config", methods=['GET'])
+def config():
+    config = jsonify(dashboard_config)
+    return config
+
+###############################################################################
 
 def main(args=None):
     server_ip = "0.0.0.0"
@@ -34,6 +43,25 @@ def main(args=None):
     if "WEB_SERVER_IP_ADDRESS" in os.environ:
         server_ip = os.environ['WEB_SERVER_IP_ADDRESS']
         print(f"Set Server IP to: {server_ip}:{port_num}")
+
+    if "DASHBOARD_CONFIG_PATH" in os.environ:
+        config_path = os.environ['DASHBOARD_CONFIG_PATH']
+        
+        if not config_path:
+            print(f"WARN! env DASHBOARD_CONFIG_PATH is empty...")
+        elif not os.path.exists(config_path):
+            print(f"File [{config_path}] doesnt exist")
+            raise FileNotFoundError
+        else:
+            try:
+                f = open(config_path, 'r')
+                global dashboard_config
+                dashboard_config = json.load(f)
+            except Exception as err:
+                print(f"Failed to read [{config_path}] dashboard config file")
+                raise err
+    else:
+        print(f"WARN! env DASHBOARD_CONFIG_PATH is not specified...")
 
     print("Starting Dispatcher Dashboard GUI Server")
     app.run(host=server_ip, debug=False, port=port_num)

--- a/rmf_demo_panel/rmf_demo_panel/gui_server.py
+++ b/rmf_demo_panel/rmf_demo_panel/gui_server.py
@@ -18,21 +18,24 @@ from flask import Flask, render_template, jsonify
 import os
 import sys
 import requests
-import json 
+import json
 
 ###############################################################################
 
 app = Flask(__name__, static_url_path="/static")
 dashboard_config = {"world_name": ""}
 
+
 @app.route("/")
 def home():
     return render_template("index.html")
+
 
 @app.route("/dashboard_config", methods=['GET'])
 def config():
     config = jsonify(dashboard_config)
     return config
+
 
 ###############################################################################
 
@@ -46,7 +49,7 @@ def main(args=None):
 
     if "DASHBOARD_CONFIG_PATH" in os.environ:
         config_path = os.environ['DASHBOARD_CONFIG_PATH']
-        
+
         if not config_path:
             print(f"WARN! env DASHBOARD_CONFIG_PATH is empty...")
         elif not os.path.exists(config_path):

--- a/rmf_demo_panel/rmf_demo_panel/static/src/app.tsx
+++ b/rmf_demo_panel/rmf_demo_panel/static/src/app.tsx
@@ -5,14 +5,14 @@ import PanelsContainer from './components/panels-container';
 import Footer from './components/fixed-components/footer';
 import NavTabs from './components/fixed-components/tabs';
 import { WorldContext, World } from './components/fixed-components/app-context';
-import { getDefaultConfig } from './components/services';
+import { getDashboardConfig } from './components/services';
 
 export default function App(): React.ReactElement {
     const currWorld = React.useContext(WorldContext);
     const [currentWorld, setCurrentWorld] = React.useState(currWorld);
     
     const setDefaultConfig = async () => {
-        const defaultConfig = await getDefaultConfig();
+        const defaultConfig = await getDashboardConfig();
         setCurrentWorld({map: World.Office, config: defaultConfig});
     };
 

--- a/rmf_demo_panel/rmf_demo_panel/static/src/components/fixed-components/app-context.tsx
+++ b/rmf_demo_panel/rmf_demo_panel/static/src/components/fixed-components/app-context.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// TODO: Rethink if different world tabs are necessary (Office)
 export const Worlds = {
     0: "Office",
     1: "Airport",

--- a/rmf_demo_panel/rmf_demo_panel/static/src/components/fixed-components/tabs.tsx
+++ b/rmf_demo_panel/rmf_demo_panel/static/src/components/fixed-components/tabs.tsx
@@ -3,7 +3,7 @@ import { makeStyles, withStyles, Theme, createStyles } from '@material-ui/core/s
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import { WorldContextType, World } from './app-context';
-import { getConfigFile } from '../services';
+import { getDashboardConfig } from '../services';
 
 interface StyledTabsProps {
   value: number;
@@ -69,18 +69,22 @@ const NavTabs: React.FC<NavTabsProps> = (props: NavTabsProps) => {
 
   const handleChange = async (event: React.ChangeEvent<{}>, newValue: number) => {
     setValue(newValue);
-    const config = await getConfigFile(World[newValue]);
+    // const config = await getConfigFile(World[newValue]);
+    const config = await getDashboardConfig();
     handleWorldChange({ map: newValue, config: config });
   };
+
+  // TODO: should reflect the current "world name" to the GUI
 
   return (
     <div className={classes.root} role="nav-tabs">
       <div className={classes.tabs}>
         <StyledTabs value={value} onChange={handleChange} aria-label="styled tabs example">
-          <StyledTab label="Office" />
+          <StyledTab label="RMF World" />
+          {/* <StyledTab label="Office" />
           <StyledTab label="Airport" />
           <StyledTab label="Clinic" />
-          <StyledTab label="Hotel" />
+          <StyledTab label="Hotel" /> */}
         </StyledTabs>
       </div>
     </div>

--- a/rmf_demo_panel/rmf_demo_panel/static/src/components/services.tsx
+++ b/rmf_demo_panel/rmf_demo_panel/static/src/components/services.tsx
@@ -1,6 +1,7 @@
 import { showErrorMessage, showSuccessMessage } from './fixed-components/messages';
 
 const API_SERVER_ADD = "http://" + location.hostname + ":8080"
+const GUI_SERVER_ADD = "http://" + location.hostname + ":5000"
 
 //API endpoints
 export const getRobots = async () => {
@@ -106,39 +107,15 @@ export const submitTaskList = (taskList: any[]) => {
     showSuccessMessage(res);
 }
 
-// Getting config files from "rmf_dashboard_resources"
-import officeConfig from "../../../../../rmf_dashboard_resources/office/dashboard_config.json";
-import airportConfig from "../../../../../rmf_dashboard_resources/airport_terminal/dashboard_config.json";
-import clinicConfig from "../../../../../rmf_dashboard_resources/clinic/dashboard_config.json";
-import hotelConfig from "../../../../../rmf_dashboard_resources/hotel/dashboard_config.json";
-
-export const getDefaultConfig = async () => {
-    let response = await fetch(officeConfig.toString()).then(resp => resp.json());
-    return response;
-}
-
-export const getConfigFile = async (folderName: string) => {
-    let config: object;
-
-    switch(folderName) {
-        case 'Office':
-            config = await fetch(officeConfig.toString())
-            .then(resp => resp.json());
-            return config;
-
-        case 'Airport':
-            config = await fetch(airportConfig.toString())
-            .then(resp => resp.json());
-            return config;
-
-        case 'Clinic':
-            config = await fetch(clinicConfig.toString())
-            .then(resp => resp.json());
-            return config;
-
-        case 'Hotel':
-            config = await fetch(hotelConfig.toString())
-            .then(resp => resp.json());
-            return config;
+export const getDashboardConfig = async () => {
+    try {
+        let response = await fetch(GUI_SERVER_ADD + '/dashboard_config');
+        if(response) {
+            let data = await response.json()
+            console.log("Get Dashboard Config", data);
+            return data;
+        }
+    } catch (err) {
+        throw new Error(err.message);
     }
 }


### PR DESCRIPTION
This is to remove the npm build dependency of `dashboard_config` file, to a runtime dependency. The dashboard config file will now be specified in respective world launch file. Example in `airport_terminal.launch.xml`: 
```
<arg name="dashboard_config_file" value="$(find-pkg-share rmf_demos_dashboard_resources)/airport_terminal/dashboard_config.json"/>
```

An endpoint `IP_ADD:5000/dashboard_config` is added to the gui server. With this, the user is not required to switch to a different "world tab" on the web gui. Will have a separate PR on react GUI tabs clean up.