### PR TITLE
Generic launch

### DIFF
--- a/demos/launch/common.launch.xml
+++ b/demos/launch/common.launch.xml
@@ -5,6 +5,7 @@
   <arg name="use_sim_time" default="false" description="Use the /clock topic for time to sync with simulation"/>
   <arg name="viz_config_file" default="$(find-pkg-share rmf_schedule_visualizer)/config/rmf.rviz"/>
   <arg name="config_file" description="Building description file required by building_map_tools"/>
+  <arg name="initial_map" default="L1" description="Initial map name for the visualizer"/>
   <arg name="headless" description="do not launch rviz; launch gazebo in headless mode" default="false"/>
   <arg name="bidding_time_window" description="Time window in seconds for task bidding process" default="2.0"/>
 
@@ -28,7 +29,7 @@
   <!-- Visualizer -->
   <group unless="$(var headless)">
     <include file="$(find-pkg-share visualizer)/visualizer.xml">
-      <arg name="map_name" value="L1"/>
+      <arg name="map_name" value="$(var initial_map)"/>
       <arg name="viz_config_file" value ="$(var viz_config_file)"/>
     </include>
   </group>

--- a/demos/launch/simulation.launch.xml
+++ b/demos/launch/simulation.launch.xml
@@ -1,14 +1,15 @@
 <?xml version='1.0' ?>
 
 <launch>
+  <arg name="map_package" default="rmf_demo_maps" description="Name of the map package" />
   <arg name="map_name" description="Name of the rmf_demos map to simulate" />
   <arg name="use_ignition" default="0" />
 
   <!-- Gazebo classic was chosen-->
   <group unless="$(var use_ignition)">
     <arg name="gazebo_version" default="11"/>
-    <let name="world_path" value="$(find-pkg-share rmf_demo_maps)/maps/$(var map_name)/$(var map_name).world" />
-    <let name="model_path" value="$(find-pkg-share rmf_demo_maps)/maps/$(var map_name)/models:$(find-pkg-share rmf_demo_assets)/models:/usr/share/gazebo-$(var gazebo_version)/models" />
+    <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/$(var map_name).world" />
+    <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)/models:$(find-pkg-share rmf_demo_assets)/models:/usr/share/gazebo-$(var gazebo_version)/models" />
     <let name="resource_path" value="$(find-pkg-share rmf_demo_assets):/usr/share/gazebo-$(var gazebo_version)" />
     <let name="plugin_path" value="$(find-pkg-prefix rmf_gazebo_plugins)/lib:$(find-pkg-prefix building_gazebo_plugins)/lib:/usr/share/gazebo-$(var gazebo_version)" />
 
@@ -29,8 +30,8 @@
 
   <!-- Ignition was chosen-->
   <group if="$(var use_ignition)">
-    <let name="world_path" value="$(find-pkg-share rmf_demo_maps)/maps/$(var map_name)_ign/$(var map_name).world" />
-    <let name="model_path" value="$(find-pkg-share rmf_demo_maps)/maps/$(var map_name)_ign/models:$(find-pkg-share rmf_demo_assets)/models:$(env HOME)/.gazebo/models" />
+    <let name="world_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/$(var map_name).world" />
+    <let name="model_path" value="$(find-pkg-share $(var map_package))/maps/$(var map_name)_ign/models:$(find-pkg-share rmf_demo_assets)/models:$(env HOME)/.gazebo/models" />
     <let name="plugin_path" value="$(find-pkg-prefix rmf_ignition_plugins)/lib:$(find-pkg-prefix building_ignition_plugins)/lib" />
     <executable cmd="ign gazebo -r -v 4 $(var world_path)" output="both">
 


### PR DESCRIPTION
This PR makes the `rmf_demos` launch files more generic so they can be reused by downstream packages. I think this will be helpful for users to get their own custom simulation demos working quickly and easily.